### PR TITLE
Add a wrapper around rspec

### DIFF
--- a/bin/puppet_rspec
+++ b/bin/puppet_rspec
@@ -1,0 +1,7 @@
+require 'rubygems'
+
+version = "= 2.9.0"
+
+gem 'rspec-expectations', version
+gem 'rspec-core', version
+load Gem.bin_path('rspec-core', 'rspec', version)

--- a/lib/puppetlabs_spec_helper/puppet_spec_helper.rb
+++ b/lib/puppetlabs_spec_helper/puppet_spec_helper.rb
@@ -4,9 +4,8 @@ require 'puppetlabs_spec_helper/puppetlabs_spec_helper'
 ARGV.clear
 
 require 'puppet'
-require 'mocha'
-gem 'rspec', '>=2.0.0'
 require 'rspec/expectations'
+require 'mocha'
 
 require 'pathname'
 require 'tmpdir'

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -8,6 +8,7 @@ desc "Run spec tests on an existing fixtures directory"
 RSpec::Core::RakeTask.new(:spec_standalone) do |t|
   t.rspec_opts = ['--color']
   t.pattern = 'spec/{classes,defines,unit}/**/*_spec.rb'
+  t.rspec_path = 'puppet_rspec'
 end
 
 desc "Generate code coverage information"

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -14,9 +14,12 @@ Gem::Specification.new do |s|
  
   s.add_dependency("rake")
   s.add_dependency("rspec", "= 2.9.0")
+  s.add_dependency("rspec-expectations", "= 2.9.0")
   s.add_dependency("mocha", "= 0.10.5")
   s.add_dependency("rspec-puppet", ">= 0.1.1")
  
   s.files        = Dir.glob("lib/**/*") + %w(LICENSE)
   s.require_path = 'lib'
+
+  s.executables << 'puppet_rspec'
 end


### PR DESCRIPTION
Unfortunately, rspec does not handle having multiple versions installed side- by-side. Because we require an older version, we need to handle loading the rspec and rspec-expectations gems manually in order to avoid version conflicts when an end-user has the latest version installed next to our version.
