### PR TITLE
Don't require specific versions of packages in the gem.

### DIFF
--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
   s.description = "Contains rake tasks and a standard spec_helper for running spec tests on puppet modules"
  
   s.add_dependency("rake")
-  s.add_dependency("rspec", "= 2.9.0")
-  s.add_dependency("mocha", "= 0.10.5")
+  s.add_dependency("rspec", ">= 2.9.0")
+  s.add_dependency("mocha", ">= 0.10.5")
   s.add_dependency("rspec-puppet", ">= 0.1.1")
  
   s.files        = Dir.glob("lib/**/*") + %w(LICENSE)


### PR DESCRIPTION
Specific versions were added for our QA requirements. Unfortunately, they can cause some rubygem conflicts on end users' machines. We'll handle the specific QA versions in our CI scripts and just require more general versions in the gemspec.
