### PR TITLE
Create missing spec/fixtures/manifests

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -54,6 +54,7 @@ task :spec_prep do
     File::exists?(target) || FileUtils::ln_s(source, target)
   end
 
+  FileUtils::mkdir_p("spec/fixtures/manifests")
   FileUtils::touch("spec/fixtures/manifests/site.pp")
 end
 


### PR DESCRIPTION
$ rake spec_prep
(in /Users/mafalb/puppet/modules/xxx)
rake aborted!
No such file or directory - spec/fixtures/manifests/site.pp

This is happening because spec/fixtures/manifests is not present, so the touch of site.pp is failing.
