### PR TITLE
fix broken coverage rake task.

### DIFF
--- a/lib/puppetlabs_spec_helper/module_spec_helper.rb
+++ b/lib/puppetlabs_spec_helper/module_spec_helper.rb
@@ -1,5 +1,5 @@
-require 'puppetlabs_spec_helper/puppet_spec_helper'
 require 'rspec-puppet'
+require 'puppetlabs_spec_helper/puppet_spec_helper'
 
 def param_value(subject, type, title, param)
   subject.resource(type, title).send(:parameters)[param.to_sym]


### PR DESCRIPTION
$ rake coverage
...
/Library/Ruby/Gems/1.8/gems/puppetlabs_spec_helper-0.1.0/lib/puppetlabs_spec_helper/puppetlabs_spec/matchers.rb:8:in `alias_method': undefined method`should' for module `RSpec::Matchers::BlockAliases' (NameError)
    from /Library/Ruby/Gems/1.8/gems/puppetlabs_spec_helper-0.1.0/lib/puppetlabs_spec_helper/puppetlabs_spec/matchers.rb:8
...
