### PR TITLE
(do not merge) Add support for modules which use hiera-puppet

### DIFF
--- a/lib/puppetlabs_spec_helper/module_spec_helper.rb
+++ b/lib/puppetlabs_spec_helper/module_spec_helper.rb
@@ -20,4 +20,8 @@ module_path = [module_path, env_module_path].join(':') if env_module_path
 RSpec.configure do |c|
   c.module_path = module_path
   c.manifest_dir = File.join(fixture_path, 'manifests')
+  # The hiera config file seems to drop the top path component
+  # from this option, so we need to add a dummy component to 
+  # make everything work correctly
+  c.config = File.join(fixture_path, 'heira')
 end

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -56,6 +56,18 @@ task :spec_prep do
 
   FileUtils::mkdir_p("spec/fixtures/manifests")
   FileUtils::touch("spec/fixtures/manifests/site.pp")
+  File::open("spec/fixtures/hiera.yaml", 'w') do |f|
+    f.puts <<-EOF
+---
+:hierarchy:
+  - spec_hiera
+:backends:
+  - yaml
+  - puppet
+:yaml:
+  :datadir: './spec/fixtures'
+EOF
+    end
 end
 
 desc "Clean up the fixtures directory"
@@ -69,6 +81,7 @@ task :spec_clean do
   end
 
   FileUtils::rm("spec/fixtures/manifests/site.pp")
+  FileUtils::rm("spec/fixtures/hiera.yaml")
 end
 
 desc "Run spec tests in a clean fixtures directory"


### PR DESCRIPTION
This adds basic support for testing modules which use hiera-puppet.

I'm not sure if it is sufficient to give good test coverage, so I'd like to solicit feedback from the company and the community before this gets merged.

Specifically: when testing classes with traditional params, we can override those params on a per-test basis. Can something similar be done for hiera? If not, should that support be part of our spec helper or part of rspec-puppet? If so, is there anything else needed in this spec helper to interact cleanly with the existing functionality?
