### PR TITLE
Call puppet-lint directly

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -97,9 +97,7 @@ end
 
 desc "Check puppet manifests with puppet-lint"
 task :lint do
-  # This requires pull request: https://github.com/rodjek/puppet-lint/pull/81
-  system("puppet-lint manifests")
-  system("puppet-lint tests")
+  require 'puppet-lint/tasks/puppet-lint'
 end
 
 desc "Display the list of available rake tasks"


### PR DESCRIPTION
Hi,

First, forgive me as my ruby skill are pretty weak, however I tested the following and it seems to work on my local development box.  And, to me, seems easier then calling system() functions.

Thoughts?

Signed-off-by: Paul Belanger paul.belanger@polybeacon.com
