### PR TITLE
Work around an annoyance of mocha 0.12.0

### DIFF
--- a/lib/puppetlabs_spec_helper/puppet_spec_helper.rb
+++ b/lib/puppetlabs_spec_helper/puppet_spec_helper.rb
@@ -3,6 +3,9 @@ require 'puppetlabs_spec_helper/puppetlabs_spec_helper'
 # Don't want puppet getting the command line arguments for rake or autotest
 ARGV.clear
 
+# This is needed because we're using mocha with rspec instead of Test::Unit or MiniTest
+ENV['MOCHA_OPTIONS']='skip_integration'
+
 require 'puppet'
 require 'mocha'
 gem 'rspec', '>=2.0.0'


### PR DESCRIPTION
Mocha 0.12.0 tries to integrate with `Test::Unit` by default, and fails since we use rspec. This patch disables that integration so that our tests will run on systems with the newest version of mocha installed.
