### PR TITLE
Add additional supported rspec-puppet directories

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -7,7 +7,7 @@ task :default => [:help]
 desc "Run spec tests on an existing fixtures directory"
 RSpec::Core::RakeTask.new(:spec_standalone) do |t|
   t.rspec_opts = ['--color']
-  t.pattern = 'spec/{classes,defines,unit}/**/*_spec.rb'
+  t.pattern = 'spec/{classes,defines,unit,functions,hosts}/**/*_spec.rb'
 end
 
 desc "Generate code coverage information"


### PR DESCRIPTION
This commit adds support for two additional rspec-puppet directories.
- hosts - for files that use rspec puppet to test node declarations
- functions - for files that use rspec puppet to test puppet functions
