### PR TITLE
Add PuppetInternals.function_method compatibility bridge

### DIFF
--- a/lib/puppetlabs_spec_helper/puppetlabs_spec/puppet_internals.rb
+++ b/lib/puppetlabs_spec_helper/puppetlabs_spec/puppet_internals.rb
@@ -46,9 +46,23 @@ module PuppetlabsSpec
 
     def node(parts = {})
       node_name = parts[:name] || 'testinghost'
+      options = parts[:options] || {}
       node_environment = Puppet::Node::Environment.new(parts[:environment] || 'test')
-      Puppet::Node.new(node_name) #, :environment => node_environment)
+      options.merge!({:environment => node_environment})
+      Puppet::Node.new(node_name, options)
     end
     module_function :node
+
+    # Return a method instance for a given function.  This is primarily useful
+    # for rspec-puppet
+    def function_method(name, parts = {})
+      scope = parts[:scope] || scope()
+      # Ensure the method instance is defined by side-effect of checking if it
+      # exists.  This is a hack, but at least it's a hidden hack and not an
+      # exposed hack.
+      return nil unless Puppet::Parser::Functions.function(name)
+      scope.method("function_#{name}".intern)
+    end
+    module_function :function_method
   end
 end

--- a/spec/unit/puppetlabs_spec_helper/puppetlabs_spec/puppet_internals_spec.rb
+++ b/spec/unit/puppetlabs_spec_helper/puppetlabs_spec/puppet_internals_spec.rb
@@ -68,5 +68,25 @@ describe PuppetlabsSpec::PuppetInternals do
     it "defaults to a name of testinghost" do
       subject.node.name.should == "testinghost"
     end
+
+    it "accepts facts via options for rspec-puppet" do
+      fact_values = { 'fqdn' => "jeff.puppetlabs.com" }
+      node = subject.node(:options => { :parameters => fact_values })
+      node.parameters.should == fact_values
+    end
+  end
+
+  describe ".function_method" do
+    it "accepts an injected scope" do
+      Puppet::Parser::Functions.expects(:function).with("my_func").returns(true)
+      scope = mock()
+      scope.expects(:method).with(:function_my_func).returns(:fake_method)
+      subject.function_method("my_func", :scope => scope).should == :fake_method
+    end
+    it "returns nil if the function doesn't exist" do
+      Puppet::Parser::Functions.expects(:function).with("my_func").returns(false)
+      scope = mock()
+      subject.function_method("my_func", :scope => scope).should be_nil
+    end
   end
 end


### PR DESCRIPTION
Without this patch modules typically get entire scope objects in an effort to
invoke parser functions.  RSpec::Puppet uses the method instance itself to
send the :call message to the method instance.  The spec helper does not
provide a compatible way to obtain method instances for parser functions.

This is a problem because we need a compatible way to test functions that
does not incur a high maintenance cost on rspec-puppet.

This patch fixes the problem by implementing and compatible way to test
functions using their method instances.  RSpec::Puppet has been patched in
https://github.com/rodjek/rspec-puppet/pull/39 to use this compatibility
layer.
