### PR TITLE
(#15464) Make contributing easy via bundle Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/.noexec.yaml
+++ b/.noexec.yaml
@@ -1,0 +1,4 @@
+--- 
+exclude:
+ - rake
+ - rspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,14 @@
+source :rubygems
+
+gemspec
+
+group(:development, :test) do
+  gem "rspec", "~> 2.10.0", :require => false
+  gem "mocha", "~> 0.10.5", :require => false
+end
+
+if File.exists? "#{__FILE__}.local"
+  eval(File.read("#{__FILE__}.local"), binding)
+end
+
+# vim:filetype=ruby

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -19,19 +19,31 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<rake>, [">= 0"])
-      s.add_runtime_dependency(%q<rspec>, [">= 2.9.0"])
-      s.add_runtime_dependency(%q<mocha>, [">= 0.10.5"])
+      s.add_runtime_dependency(%q<mocha>, ["~> 0.10.5"])
+      s.add_runtime_dependency(%q<rspec>, ["~> 2.10.0"])
+      s.add_runtime_dependency(%q<rspec-core>, ["~> 2.10.0"])
+      s.add_runtime_dependency(%q<rspec-expectations>, ["~> 2.10.0"])
       s.add_runtime_dependency(%q<rspec-puppet>, [">= 0.1.1"])
+      s.add_runtime_dependency(%q<puppet>, [">= 2.6.0"])
+      s.add_runtime_dependency(%q<puppet-lint>, [">= 0"])
     else
       s.add_dependency(%q<rake>, [">= 0"])
-      s.add_dependency(%q<rspec>, [">= 2.9.0"])
-      s.add_dependency(%q<mocha>, [">= 0.10.5"])
+      s.add_dependency(%q<mocha>, ["~> 0.10.5"])
+      s.add_dependency(%q<rspec>, ["~> 2.10.0"])
+      s.add_dependency(%q<rspec-core>, ["~> 2.10.0"])
+      s.add_dependency(%q<rspec-expectations>, ["~> 2.10.0"])
       s.add_dependency(%q<rspec-puppet>, [">= 0.1.1"])
+      s.add_dependency(%q<puppet>, [">= 2.6.0"])
+      s.add_dependency(%q<puppet-lint>, [">= 0"])
     end
   else
     s.add_dependency(%q<rake>, [">= 0"])
-    s.add_dependency(%q<rspec>, [">= 2.9.0"])
-    s.add_dependency(%q<mocha>, [">= 0.10.5"])
+    s.add_dependency(%q<mocha>, ["~> 0.10.5"])
+    s.add_dependency(%q<rspec>, ["~> 2.10.0"])
+    s.add_dependency(%q<rspec-core>, ["~> 2.10.0"])
+    s.add_dependency(%q<rspec-expectations>, ["~> 2.10.0"])
     s.add_dependency(%q<rspec-puppet>, [">= 0.1.1"])
+    s.add_dependency(%q<puppet>, [">= 2.6.0"])
+    s.add_dependency(%q<puppet-lint>, [">= 0"])
   end
 end


### PR DESCRIPTION
Without this patch the process of figuring out how to quickly set up a
development and testing environment for the Puppet _application_ (not a
gem library) is unnecessarily complicated.

This patch addresses the problem by providing a Bundler compatible Gemfile
that specifies all of the Gem dependencies for the Puppet 2.7 application.

Puppet contributors can now easily get a working development and testing
environment using this sequence of commands:

```
$ git clone git://github.com/puppetlabs/puppetlabs_spec_helper
$ cd puppetlabs_spec_helper
$ bundle install # Install all required dependencies
$ rspec
```

The .noexec.yaml file excludes the `rake` command so that the Gemfile
doesn't raise an exception if the `rubygems-bundler` Gem is installed and
automatically running `bundle exec` for us.
