### PR TITLE
Use mocha_standalone because we are not using Test::Unit or MiniTest

### DIFF
--- a/lib/puppetlabs_spec_helper/puppet_spec_helper.rb
+++ b/lib/puppetlabs_spec_helper/puppet_spec_helper.rb
@@ -7,7 +7,7 @@ ARGV.clear
 ENV['MOCHA_OPTIONS']='skip_integration'
 
 require 'puppet'
-require 'mocha'
+require 'mocha_standalone'
 gem 'rspec', '>=2.0.0'
 require 'rspec/expectations'
 


### PR DESCRIPTION
This pull request gets rid of the "use mocha_standalone" warning by using `mocha_standalone`.
