### PR TITLE
Only remove the site.pp if it is empty

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -67,8 +67,10 @@ task :spec_clean do
   fixtures("symlinks").each do |source, target|
     FileUtils::rm(target)
   end
-
-  FileUtils::rm("spec/fixtures/manifests/site.pp")
+  site = "spec/fixtures/manifests/site.pp"
+  if File::exists?(site) and ! File.size?(site)
+    FileUtils::rm("spec/fixtures/manifests/site.pp")
+  end
 end
 
 desc "Run spec tests in a clean fixtures directory"


### PR DESCRIPTION
The rspec-puppet documentation mentions than any node definitions for node tests should be placed in spec/fixtures/manifests/site.pp, but this file is uncontitionally removed by `rake spec_clean`. This commit changes that behaviour to only remove site.pp if it is empty.
