### PR TITLE
add backwards-compatible support for arbitrary git refs in .fixtures.yml

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -76,7 +76,12 @@ end
 
 desc "Clean up the fixtures directory"
 task :spec_clean do
-  fixtures("repositories").each do |repo, target|
+  fixtures("repositories").each do |remote, opts|
+    if opts.instance_of?(String)
+      target = opts
+    elsif opts.instance_of?(Hash)
+      target = opts["target"]
+    end
     FileUtils::rm_rf(target)
   end
 


### PR DESCRIPTION
e.g. `.fixtures.yml`:

```
fixtures:
  repositories:
    stdlib: 
      repo: git://github.com/puppetlabs/puppetlabs-stdlib
      ref: fd52b8d88a943aef529adfc06cf709ac35509dc5
#     stdlib: git://github.com/puppetlabs/puppetlabs-stdlib
  symlinks:
    my_module: "#{source_dir}"
```
