### PR TITLE
Fix Mocha deprecations

### DIFF
--- a/lib/puppetlabs_spec_helper/puppet_spec_helper.rb
+++ b/lib/puppetlabs_spec_helper/puppet_spec_helper.rb
@@ -7,9 +7,9 @@ ARGV.clear
 ENV['MOCHA_OPTIONS']='skip_integration'
 
 require 'puppet'
-require 'mocha'
 gem 'rspec', '>=2.0.0'
 require 'rspec/expectations'
+require 'mocha/api'
 
 require 'pathname'
 require 'tmpdir'


### PR DESCRIPTION
With the Mocha version that puppetlabs_spec_helper is depending, there are deprecation errors when using it:

```
/Users/mitchellh/.rbenv/versions/1.9.3-p327/bin/ruby -S rspec spec/classes/libffi_darwin_spec.rb spec/classes/libffi_merge_environment_spec.rb spec/classes/libffi_spec.rb

*** Mocha deprecation warning: Change `require 'mocha'` to `require 'mocha/setup'`.


*** Mocha deprecation warning: Test::Unit or MiniTest must be loaded *before* Mocha.


*** Mocha deprecation warning: If you're integrating with a test library other than Test::Unit or MiniTest, you should use `require 'mocha/api'` instead of `require 'mocha'`.
```

This fixes those errors.
