### PR TITLE
Rake should fail if git can't clone repository

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -61,7 +61,9 @@ task :spec_prep do
       ref = opts["ref"]
     end
 
-    File::exists?(target) || system("git clone #{remote} #{target}")
+    unless File::exists?(target) || system("git clone #{remote} #{target}")
+      fail "Failed to clone #{remote} into #{target}"
+    end
     system("cd #{target}; git reset --hard #{ref}") if ref
   end
 


### PR DESCRIPTION
If for some reason git can't connect to the internet to clone the repo the build continues, maybe failing later in the specs with missing fixtures.
This patch makes it fail fast with the right message

Closes #23
