### PR TITLE
Don't reset when target is missing

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -55,7 +55,6 @@ task :spec_prep do
   fixtures("repositories").each do |remote, opts|
     if opts.instance_of?(String)
       target = opts
-      ref = "refs/remotes/origin/master"
     elsif opts.instance_of?(Hash)
       target = opts["target"]
       ref = opts["ref"]


### PR DESCRIPTION
If the target repository clone does not exist (when ^C was pressed, for
example) then the `cd` command will fail, but the `git reset` will still
be run. This will reset the current working dir from which `rake` was
ran to be reset to `ref`. This commit keeps that from happening.
