### PR TITLE
(#18165) Mark tests pending on broken puppet versions

### DIFF
--- a/spec/unit/spechelper_spec.rb
+++ b/spec/unit/spechelper_spec.rb
@@ -7,13 +7,37 @@ Puppet[:confdir]
 # set modulepath from which to load custom type
 Puppet[:modulepath] = File.join(File.dirname(__FILE__), '..', '..')
 
+def should_be_able_to_load_types?
+  return true if Puppet::Test::TestHelper.respond_to?(:initialize)
+
+  case Puppet.version
+  when /^2\.7\.20/
+    false
+  when /^3\.0\./
+    false
+  else
+    true
+  end
+end
+
 # construct a top-level describe block whose declared_class is a custom type in this module
 describe Puppet::Type.type(:spechelper) do
   it "should load the type from the modulepath" do
-    described_class.should be
+    pending("this is only supported on newer versions of puppet", :unless => should_be_able_to_load_types?) do
+      described_class.should be
+    end
   end
 
   it "should have a doc string" do
-    described_class.doc.should == "This is the spechelper type"
+    pending("this is only supported on newer versions of puppet", :unless => should_be_able_to_load_types?) do
+      described_class.doc.should == "This is the spechelper type"
+    end
+  end
+end
+
+describe "Setup of settings" do
+  it "sets confdir and vardir to something not meaningful to force tests to make their choice explicit" do
+    Puppet[:confdir].should == "/dev/null"
+    Puppet[:vardir].should == "/dev/null"
   end
 end


### PR DESCRIPTION
The test that was created for #18165 assumed that it was working against
a version of puppet in which we could correctly load code. This is the
case for some versions of puppet that we try to support, but not
others. The versions that work are: 2.7 between 2.7.14 and 2.7.19, but
2.7.20 is broken. All of the 3.0 series is broken, but if the code has
an `initialize` method, which will appear in 3.1, then it should work.

This commit adds this check for marking the appropriate tests as
pending. In addition it adds tests to make sure we are setting up the
confdir and vardir as a proxy for settings getting initialized.
