### PR TITLE
Fix issue with aborted rake task when packaging gem.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require 'rake'
 require 'rake/packagetask'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 
 task :default do
     sh %{rake -T}


### PR DESCRIPTION
When attempting to package the gem, the following error is thrown and the task is aborted.
This patch updates the Rakefile to use the correct task for packaging.

$ rake package:gem
rake aborted!
ERROR: 'rake/gempackagetask' is obsolete and no longer supported. Use 'rubygems/package_task' instead.
/home/acline/Development/puppetlabs_spec_helper/Rakefile:3:in `<top (required)>'
/home/acline/.rvm/gems/ruby-1.9.3-p194/bin/ruby_noexec_wrapper:14:in`eval'
/home/acline/.rvm/gems/ruby-1.9.3-p194/bin/ruby_noexec_wrapper:14:in `<main>'
(See full trace by running task with --trace)
