### PR TITLE
(#21602) Updated rake_tasks.rb to include 'integration' folder when running spec tests.

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -7,7 +7,7 @@ task :default => [:help]
 desc "Run spec tests on an existing fixtures directory"
 RSpec::Core::RakeTask.new(:spec_standalone) do |t|
   t.rspec_opts = ['--color']
-  t.pattern = 'spec/{classes,defines,unit,functions,hosts}/**/*_spec.rb'
+  t.pattern = 'spec/{classes,defines,unit,functions,hosts,integration}/**/*_spec.rb'
 end
 
 desc "Generate code coverage information"


### PR DESCRIPTION
Added 'integration' to the directories considered when running :spec_standalone from rake_tasks.rb. 
