### PR TITLE
Fix for empty repository list in .fixtures.yml file

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -33,7 +33,7 @@ def fixtures(category)
   end
 
   result = {}
-  if fixtures.include? category
+  if fixtures.include? category and fixtures[category] != nil
     fixtures[category].each do |fixture, opts|
       if opts.instance_of?(String)
         source = opts


### PR DESCRIPTION
Came across an issue w/ the fixtures function in rake_tasks.rb throwing exceptions when a .fixtures.yml file like the following is provided:

```
# see http://github.com/puppetlabs/puppetlabs_spec_helper
fixtures:
  repositories:
#   stdlib: 'git://github.com/puppetlabs/puppetlabs-stdlib'
  symlinks:
    ntp: "#{source_dir}"
```

I use puppetlabs_spec_helper as part of a tool that I internally curate inside my company to make creating Puppet modules easy and consistent. I wanted to provide the above .fixtures.yml file as a template .fixtures.yml file for each Puppet module a dev of mine may create. We use a lot of stdlib functionality but I didn't want to fully enable the repo. However - the above file caused the said fixtures function within the rake_tasks.rb file to not be happy.

Thus, the fix in this commit is simply to not do anything if the passed in category is missing and if it is provided in the file but doesn't contain any data.

I'm still a bit of a Ruby noob so my proposal may not be up to par w/ Ruby syntax style.

Cheers,
Tehmasp
