### PR TITLE
Changed to forced symlinks in the event that symlink is old a spec_prep ...

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -68,7 +68,7 @@ task :spec_prep do
 
   FileUtils::mkdir_p("spec/fixtures/modules")
   fixtures("symlinks").each do |source, target|
-    File::exists?(target) || FileUtils::ln_s(source, target)
+    File::exists?(target) || FileUtils::ln_sf(source, target)
   end
 
   FileUtils::mkdir_p("spec/fixtures/manifests")


### PR DESCRIPTION
...should simply force updating symlinks based on .fixtures.yml configuration.

Without this - if someone moves a project directory they have to remove the symlink manually before the spec_prep task can be run successfully.
