### PR TITLE
spec_clean does not fail if it has already been run

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -87,12 +87,9 @@ task :spec_clean do
   end
 
   fixtures("symlinks").each do |source, target|
-    FileUtils::rm(target)
+    FileUtils::rm_f(target)
   end
-  site = "spec/fixtures/manifests/site.pp"
-  if File::exists?(site) and ! File.size?(site)
-    FileUtils::rm("spec/fixtures/manifests/site.pp")
-  end
+  FileUtils::rm_f("spec/fixtures/manifests/site.pp")
 end
 
 desc "Run spec tests in a clean fixtures directory"


### PR DESCRIPTION
I should be able to run `rake spec_clean` as many times as I'd like.

**before**:

```
➜  puppet-pulp  rake spec_prep
➜  puppet-pulp  rake spec_clean
➜  puppet-pulp  rake spec_clean
rake aborted!
No such file or directory - spec/fixtures/modules/pulp
/Users/hnewton/Projects/puppetlabs_spec_helper/lib/puppetlabs_spec_helper/rake_tasks.rb:90:in `block (2 levels) in <top (required)>'
/Users/hnewton/Projects/puppetlabs_spec_helper/lib/puppetlabs_spec_helper/rake_tasks.rb:89:in `each'
/Users/hnewton/Projects/puppetlabs_spec_helper/lib/puppetlabs_spec_helper/rake_tasks.rb:89:in `block in <top (required)>'
/Users/hnewton/.rvm/gems/ruby-1.9.3-p448@puppet-pulp/bin/ruby_noexec_wrapper:14:in `eval'
/Users/hnewton/.rvm/gems/ruby-1.9.3-p448@puppet-pulp/bin/ruby_noexec_wrapper:14:in `<main>'
Tasks: TOP => spec_clean
(See full trace by running task with --trace)
```

**after**:

```
➜  puppet-pulp  rake spec_prep
➜  puppet-pulp  rake spec_clean
➜  puppet-pulp  rake spec_clean
```
