### PR TITLE
Update the Rake file for Gems > 2.x.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -44,7 +44,7 @@ namespace :package do
 	Gem::Package.build(spec)
       else
 	Gem::Builder.new(spec).build
-      end 
+      end
       FileUtils.move("puppetlabs_spec_helper-#{version}.gem", "pkg")
   end
 end


### PR DESCRIPTION
This gem won't build on Mavericks or any Ruby 2.0.0 that are using any Gems version above 2.x. This fixes that problem.
