### PR TITLE
Add support for "forge_modules" in fixtures.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -147,6 +147,16 @@ Specify that the git tag `2.4.2` of `stdlib' should be checked out:
       symlinks:
         my_module: "#{source_dir}"
 
+Install modules from Puppet Forge:
+
+    fixtures:
+        forge_modules:
+            firewall: "puppetlabs/firewall"
+            stdlib:
+                repo: "puppetlabs/stdlib"
+                ref: "2.6.0"
+
+
 Testing Parser Functions
 ========================
 

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -71,6 +71,22 @@ task :spec_prep do
     File::exists?(target) || FileUtils::ln_sf(source, target)
   end
 
+  fixtures("forge_modules").each do |remote, opts|
+    if opts.instance_of?(String)
+      target = opts
+      ref = ""
+    elsif opts.instance_of?(Hash)
+      target = opts["target"]
+      ref = "--version #{opts['ref']}"
+    end
+    next if File::exists?(target)
+    unless system("puppet module install " + ref + \
+                  " --ignore-dependencies" \
+                  " --target-dir spec/fixtures/modules #{remote}")
+      fail "Failed to install module #{remote} to #{target}"
+    end
+  end
+
   FileUtils::mkdir_p("spec/fixtures/manifests")
   FileUtils::touch("spec/fixtures/manifests/site.pp")
 end
@@ -78,6 +94,15 @@ end
 desc "Clean up the fixtures directory"
 task :spec_clean do
   fixtures("repositories").each do |remote, opts|
+    if opts.instance_of?(String)
+      target = opts
+    elsif opts.instance_of?(Hash)
+      target = opts["target"]
+    end
+    FileUtils::rm_rf(target)
+  end
+
+  fixtures("forge_modules").each do |remote, opts|
     if opts.instance_of?(String)
       target = opts
     elsif opts.instance_of?(Hash)


### PR DESCRIPTION
- This adds a new _forge_modules_ category, similar to _repositories_,
  it can be given as a simple string argument, or with a hash to specify
  version.
- I have done local testing, but I'm not sure how feasible it is to
  write unit tests for something like this. (There seem to not be any for
  existing rake tests.)
- I ignore dependencies when installing fixture modules.  Since we don't
  clean directories that are not expressly listed, we shouldn't install
  dependencies because they won't be cleaned up.  Besides, it's probably
  better to have to be explicit about your chain of dependencies.
- "repo" and "ref" don't really work as well as for git repos, but
  renaming them is outside the scope of this change and I didn't really
  want to make it any more complicated than necessary.
- I see the direct uses of the module face in the `build` task, but the
  `build` task doesn't work for me (ironically enough, it seems like some
  of initialization that this gem supplies needs to be done):
  
  Could not autoload puppet/face/module/install: Error converting value for param 'modulepath': Could not find value for $confdir

In fact, this happens when I do the same thing w/irb:

```
irb(main):001:0> require 'puppet/face'
=> true
irb(main):002:0> pmod = Puppet::Face['module', :current]
Puppet::Error: Could not autoload puppet/face/module/install: Error converting value for param 'modulepath': Could not find value for $confdir
```

... so I'm just shelling out to 'puppet module install' directly.
