### PR TITLE
spec_prep updates git repos if target exists

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -66,8 +66,10 @@ task :spec_prep do
       ref = opts["ref"]
     end
 
-    unless File::exists?(target) || system("git clone #{remote} #{target}")
-      fail "Failed to clone #{remote} into #{target}"
+    if File::exists?(target)
+      warn "Failed to update #{target}" if !system("cd #{target}; git pull")
+    else
+      fail "Failed to clone #{remote} into #{target}" if !system("git clone #{remote} #{target}")
     end
     system("cd #{target} && git reset --hard #{ref}") if ref
   end


### PR DESCRIPTION
I am frequently without internet access and have configured rake to not clear my fixtures directory upon success with:

task :spec => []; Rake::Task[:spec].clear
task :spec do
  Rake::Task[:spec_prep].invoke
  Rake::Task[:spec_standalone].invoke
end

This updates fixture modules if they're already present, otherwise works as before.  My other thought would be to add a new task (spec_update?) that just accomplished this.

https://tickets.puppetlabs.com/browse/PUP-1660