### PR TITLE
Only clean up site.pp fixture if zero length

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -89,7 +89,11 @@ task :spec_clean do
   fixtures("symlinks").each do |source, target|
     FileUtils::rm_f(target)
   end
-  FileUtils::rm_f("spec/fixtures/manifests/site.pp")
+
+  if File.zero?("spec/fixtures/manifets/site.pp")
+    FileUtils::rm_f("spec/fixtures/manifests/site.pp")
+  end
+
 end
 
 desc "Run spec tests in a clean fixtures directory"


### PR DESCRIPTION
If the site.pp is not zero-length, then there is a good chance that
it is actually being used for something. In that case, cleaning it up
would be surprising and potentially lose work if not already committed.
