### PR TITLE
add puppet-lint to gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 group(:development, :test) do
   gem "rspec", "~> 2.10.0", :require => false
   gem "mocha", "~> 0.10.5", :require => false
+  gem "puppet-lint", "~> 0.3.2", :require => false
 end
 
 if File.exists? "#{__FILE__}.local"


### PR DESCRIPTION
puppet-lint is required to run the included 'lint' Rake task so include it in the dependencies
