### PR TITLE
MODULES-998: Update link to Jira issue tracker

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -49,7 +49,7 @@ Issues
 ======
 
 Please file issues against this project at the [Puppet Labs Issue
-Tracker](http://projects.puppetlabs.com/projects/ci-modules)
+Tracker](https://tickets.puppetlabs.com/browse/MODULES)
 
 The Long Version
 ----------------


### PR DESCRIPTION
Updating link for issues to Jira.  When I submitted a PR previously for this I wasn't sure what project to put it in, an update to this may be warranted to specify the preferred Jira project.
