### PR TITLE
Update pinned version for gemspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,8 +29,8 @@ spec = Gem::Specification.new do |s|
   s.licenses    = 'Apache-2.0'
 
   s.add_dependency("rake")
-  s.add_dependency("rspec", ">= 2.9.0")
-  s.add_dependency("mocha", ">= 0.10.5")
+  s.add_dependency("rspec", "~> 2.10.0")
+  s.add_dependency("mocha", "~> 0.10.5")
   s.add_dependency("rspec-puppet", ">= 0.1.1")
 
   s.files        = Dir.glob("lib/**/*") + %w(LICENSE) + %w(CHANGELOG)


### PR DESCRIPTION
This commit updates the pinned version for the
gemspec dependencies to match the dependencies
from the Gemfile.

The issue is that the version was not restrictive enough
for the gemspec. This means that it started pulling in
rspec 3 as a dependency as soon as it was released.

Since many projects rely on this gem to standarize library
versions, it needs to be updated to be pinned properly to
a 2.x version.
