### PR TITLE
Release 0.4.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,15 @@
+2014-06-06 - Release 0.4.2
+
+Summary:
+This release corrects the pinning of rspec for modules which are not rspec 3
+compatible yet.
+
+Bugfixes:
+* Pin to 2.x range for rspec 2
+* Fix aborting rake task when packaging gem
+* Fix puppet issue tracker url
+* Fix issue with running `git reset` in the incorrect dir
+
 2013-02-08 Puppet Labs <info@puppetlabs.com> - 0.4.1
  * (#18165) Mark tests pending on broken puppet versions
  * (#18165) Initialize TestHelper as soon as possible

--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,6 @@ source :rubygems
 
 gemspec
 
-group(:development, :test) do
-  gem "rspec", "~> 2.10.0", :require => false
-  gem "mocha", "~> 0.10.5", :require => false
-end
-
 if File.exists? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)
 end

--- a/README.markdown
+++ b/README.markdown
@@ -49,7 +49,7 @@ Issues
 ======
 
 Please file issues against this project at the [Puppet Labs Issue
-Tracker](http://projects.puppetlabs.com/projects/ci-modules)
+Tracker](https://tickets.puppetlabs.com/browse/MODULES)
 
 The Long Version
 ----------------

--- a/Rakefile
+++ b/Rakefile
@@ -9,39 +9,17 @@ end
 require 'fileutils'
 
 def version
-# This ugly bit removes the gSHA1 portion of the describe as that causes failing tests
-  if File.exists?('.git')
-    %x{git describe}.chomp.gsub('-', '.').split('.')[0..3].join('.').gsub('v', '')
-  else
-    %x{pwd}.strip!.split('.')[-1]
-  end
-end
-
-spec = Gem::Specification.new do |s|
-  s.name        = "puppetlabs_spec_helper"
-  s.version     = version
-  s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Puppet Labs"]
-  s.email       = ["puppet-dev@puppetlabs.com"]
-  s.homepage    = "http://github.com/puppetlabs/puppetlabs_spec_helper"
-  s.summary     = "Standard tasks and configuration for module spec tests"
-  s.description = "Contains rake tasks and a standard spec_helper for running spec tests on puppet modules"
-
-  s.add_dependency("rake")
-  s.add_dependency("rspec", "~> 2.10.0")
-  s.add_dependency("mocha", "~> 0.10.5")
-  s.add_dependency("rspec-puppet", ">= 0.1.1")
-
-  s.files        = Dir.glob("lib/**/*") + %w(LICENSE) + %w(CHANGELOG)
-  s.require_path = 'lib'
+  require 'puppetlabs_spec_helper/version'
+  PuppetlabsSpecHelper::Version::STRING
 end
 
 namespace :package do
   desc "Create the gem"
   task :gem do
-      Dir.mkdir("pkg") rescue nil
-      Gem::Builder.new(spec).build
-      FileUtils.move("puppetlabs_spec_helper-#{version}.gem", "pkg")
+    spec = Gem::Specification.load("puppetlabs_spec_helper.gemspec")
+    Dir.mkdir("pkg") rescue nil
+    Gem::Builder.new(spec).build
+    FileUtils.move("puppetlabs_spec_helper-#{version}.gem", "pkg")
   end
 end
 

--- a/lib/puppetlabs_spec_helper/version.rb
+++ b/lib/puppetlabs_spec_helper/version.rb
@@ -1,0 +1,5 @@
+module PuppetlabsSpecHelper
+  module Version
+    STRING = '0.4.2'
+  end
+end

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -1,49 +1,23 @@
 # -*- encoding: utf-8 -*-
+$LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
+require "puppetlabs_spec_helper/version"
 
 Gem::Specification.new do |s|
-  s.name = "puppetlabs_spec_helper"
-  s.version = "0.3.0"
-
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["Puppet Labs"]
-  s.date = "2012-08-15"
+  s.name        = "puppetlabs_spec_helper"
+  s.version     = PuppetlabsSpecHelper::Version::STRING
+  s.authors     = ["Puppet Labs"]
+  s.email       = ["modules-dept@puppetlabs.com"]
+  s.homepage    = "http://github.com/puppetlabs/puppetlabs_spec_helper"
+  s.summary     = "Standard tasks and configuration for module spec tests"
   s.description = "Contains rake tasks and a standard spec_helper for running spec tests on puppet modules"
-  s.email = ["puppet-dev@puppetlabs.com"]
-  s.homepage = "http://github.com/puppetlabs/puppetlabs_spec_helper"
-  s.require_paths = ["lib"]
-  s.rubygems_version = "1.8.24"
-  s.summary = "Standard tasks and configuration for module spec tests"
+  s.licenses    = 'Apache-2.0'
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 3
-
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rake>, [">= 0"])
-      s.add_runtime_dependency(%q<mocha>, ["~> 0.10.5"])
-      s.add_runtime_dependency(%q<rspec>, ["~> 2.10.0"])
-      s.add_runtime_dependency(%q<rspec-core>, ["~> 2.10.0"])
-      s.add_runtime_dependency(%q<rspec-expectations>, ["~> 2.10.0"])
-      s.add_runtime_dependency(%q<rspec-puppet>, [">= 0.1.1"])
-      s.add_runtime_dependency(%q<puppet>, [">= 2.6.0"])
-      s.add_runtime_dependency(%q<puppet-lint>, [">= 0"])
-    else
-      s.add_dependency(%q<rake>, [">= 0"])
-      s.add_dependency(%q<mocha>, ["~> 0.10.5"])
-      s.add_dependency(%q<rspec>, ["~> 2.10.0"])
-      s.add_dependency(%q<rspec-core>, ["~> 2.10.0"])
-      s.add_dependency(%q<rspec-expectations>, ["~> 2.10.0"])
-      s.add_dependency(%q<rspec-puppet>, [">= 0.1.1"])
-      s.add_dependency(%q<puppet>, [">= 2.6.0"])
-      s.add_dependency(%q<puppet-lint>, [">= 0"])
-    end
-  else
-    s.add_dependency(%q<rake>, [">= 0"])
-    s.add_dependency(%q<mocha>, ["~> 0.10.5"])
-    s.add_dependency(%q<rspec>, ["~> 2.10.0"])
-    s.add_dependency(%q<rspec-core>, ["~> 2.10.0"])
-    s.add_dependency(%q<rspec-expectations>, ["~> 2.10.0"])
-    s.add_dependency(%q<rspec-puppet>, [">= 0.1.1"])
-    s.add_dependency(%q<puppet>, [">= 2.6.0"])
-    s.add_dependency(%q<puppet-lint>, [">= 0"])
-  end
+  # Runtime dependencies, but also probably dependencies of requiring projects
+  s.add_runtime_dependency 'rake'
+  s.add_runtime_dependency 'rspec-puppet'
+  s.add_runtime_dependency 'puppet'
+  s.add_runtime_dependency 'puppet-lint'
+  s.add_runtime_dependency 'rspec',              "~> 2.10"
+  # Mocha is still zero-dot and not semverically stable.
+  s.add_runtime_dependency 'mocha',              "~> 0.10.5"
 end


### PR DESCRIPTION
This release pins to rspec 2.x so that compatible modules may require
this version of puppetlabs_spec_helper and receive the correct rspec
configuration.

Future versions will pin to newer versions of rspec so that modules may
take advantage of the changes introduced in rspec 3
