### PR TITLE
Remove mocha dependency and rspec pinning

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,12 +32,10 @@ gem it contains.
 
 Add this to your project's spec\_helper.rb:
 
-    require 'rubygems'
     require 'puppetlabs_spec_helper/module_spec_helper'
 
 Add this to your project's Rakefile:
 
-    require 'rubygems'
     require 'puppetlabs_spec_helper/rake_tasks'
 
 And run the spec tests:

--- a/lib/puppetlabs_spec_helper/puppet_spec_helper.rb
+++ b/lib/puppetlabs_spec_helper/puppet_spec_helper.rb
@@ -3,13 +3,8 @@ require 'puppetlabs_spec_helper/puppetlabs_spec_helper'
 # Don't want puppet getting the command line arguments for rake or autotest
 ARGV.clear
 
-# This is needed because we're using mocha with rspec instead of Test::Unit or MiniTest
-ENV['MOCHA_OPTIONS']='skip_integration'
-
 require 'puppet'
-gem 'rspec', '>=2.0.0'
 require 'rspec/expectations'
-require 'mocha/api'
 
 require 'pathname'
 require 'tmpdir'
@@ -153,8 +148,6 @@ end
 
 # And here is where we do the main rspec configuration / setup.
 RSpec.configure do |config|
-  config.mock_with :mocha
-
   # determine whether we can use the new API or not, and call the appropriate initializer method.
   if (defined?(Puppet::Test::TestHelper))
     Puppet::PuppetSpecInitializer.initialize_via_testhelper(config)

--- a/lib/puppetlabs_spec_helper/version.rb
+++ b/lib/puppetlabs_spec_helper/version.rb
@@ -1,5 +1,5 @@
 module PuppetlabsSpecHelper
   module Version
-    STRING = '0.4.2'
+    STRING = '0.5.0'
   end
 end

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -12,12 +12,14 @@ Gem::Specification.new do |s|
   s.description = "Contains rake tasks and a standard spec_helper for running spec tests on puppet modules"
   s.licenses    = 'Apache-2.0'
 
+  s.files       = `git ls-files`.split("\n")
+  s.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+
   # Runtime dependencies, but also probably dependencies of requiring projects
   s.add_runtime_dependency 'rake'
   s.add_runtime_dependency 'rspec-puppet'
   s.add_runtime_dependency 'puppet'
   s.add_runtime_dependency 'puppet-lint'
-  s.add_runtime_dependency 'rspec',              "~> 2.10"
-  # Mocha is still zero-dot and not semverically stable.
-  s.add_runtime_dependency 'mocha',              "~> 0.10.5"
+  s.add_runtime_dependency 'rspec'
 end


### PR DESCRIPTION
Since mocha isn't really used any more, if a module needs mocha then it
should require mocha.

Since modules are written with rspec 2 or 3 syntax, PSH should not
declare dependencies on rspec at all, but leave it up to the module to
declare the dependency.
