### PR TITLE
Add mocha mocking back

### DIFF
--- a/lib/puppetlabs_spec_helper/puppet_spec_helper.rb
+++ b/lib/puppetlabs_spec_helper/puppet_spec_helper.rb
@@ -3,8 +3,12 @@ require 'puppetlabs_spec_helper/puppetlabs_spec_helper'
 # Don't want puppet getting the command line arguments for rake or autotest
 ARGV.clear
 
+# This is needed because we're using mocha with rspec instead of Test::Unit or MiniTest
+ENV['MOCHA_OPTIONS']='skip_integration'
+
 require 'puppet'
 require 'rspec/expectations'
+require 'mocha/api'
 
 require 'pathname'
 require 'tmpdir'
@@ -148,6 +152,8 @@ end
 
 # And here is where we do the main rspec configuration / setup.
 RSpec.configure do |config|
+  config.mock_with :mocha
+
   # determine whether we can use the new API or not, and call the appropriate initializer method.
   if (defined?(Puppet::Test::TestHelper))
     Puppet::PuppetSpecInitializer.initialize_via_testhelper(config)

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppet'
   s.add_runtime_dependency 'puppet-lint'
   s.add_runtime_dependency 'rspec'
+  s.add_runtime_dependency 'mocha'
 end


### PR DESCRIPTION
One of puppetlabs_spec_helpers "features" is to enable mocha mocking
support. The dependency on mocha was removed in 0.5.0 and references to
it were removed, but this caused changes in the testing behavior.

Not that mocha is the recommended mocking library (and this "feature"
should probably be removed in the future anyway), but this commit adds
it back to undo the breaking change.
