### PR TITLE
Remove puppet as a gem dependency

### DIFF
--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   # Runtime dependencies, but also probably dependencies of requiring projects
   s.add_runtime_dependency 'rake'
   s.add_runtime_dependency 'rspec-puppet'
-  s.add_runtime_dependency 'puppet'
   s.add_runtime_dependency 'puppet-lint'
   s.add_runtime_dependency 'rspec'
   s.add_runtime_dependency 'mocha'


### PR DESCRIPTION
Puppet is used as a runtime dependency of puppetlabs_spec_helper, but
is often installed by system packages and installing the gem could
create conflicts when libraries are loaded without bundler by the system
puppet.

rspec-puppet and puppet-lint do not declare puppet as a dependency, and
0.4.1 of psh did not declare it as a dependency, so it shouldn't now.
