### PR TITLE
Release 0.5.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+2014-06-19 - Release 0.5.2
+Summary:
+This release removes the previously non-existant puppet runtime dependency to
+better match rspec-puppet and puppet-lint and allow system puppet packages to
+be used instead of gems.
+
+Bugfixes:
+- Remove puppet dependency from gemspec
+
 2014-06-09 - Release 0.5.1
 Summary:
 This release re-adds mocha mocking, which was mistakenly removed in 0.5.0

--- a/lib/puppetlabs_spec_helper/version.rb
+++ b/lib/puppetlabs_spec_helper/version.rb
@@ -1,5 +1,5 @@
 module PuppetlabsSpecHelper
   module Version
-    STRING = '0.5.1'
+    STRING = '0.5.2'
   end
 end


### PR DESCRIPTION
Summary:
This release removes the previously non-existant puppet runtime
ependency to better match rspec-puppet and puppet-lint and allow system
puppet ackages to be used instead of gems.

Bugfixes:
- Remove puppet dependency from gemspec
