### PR TITLE
avoid name clash with Object.clone method

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -56,7 +56,7 @@ def fixtures(category)
   return result
 end
 
-def clone(scm, remote, target, ref=nil)
+def clone_repo(scm, remote, target, ref=nil)
   args = []
   case scm
   when 'hg'
@@ -96,7 +96,7 @@ task :spec_prep do
       scm = opts["scm"] if opts["scm"]
     end
 
-    unless File::exists?(target) || clone(scm, remote, target, ref)
+    unless File::exists?(target) || clone_repo(scm, remote, target, ref)
       fail "Failed to clone #{scm} repository #{remote} into #{target}"
     end
     revision(scm, target, ref) if ref


### PR DESCRIPTION
using rubocop in the same Rakefile yields

```
bundle exec rake rubocop
Running RuboCop...
Inspecting 10 files
private method `clone' called for #<RuboCop::Cop::CopStore:0x000001045a8250>
/Users/ehaselwanter/.rvm/gems/ruby-2.1.1/gems/rubocop-0.23.0/lib/rubocop/cop/cop.rb:57:in `all'
/Users/ehaselwanter/.rvm/gems/ruby-2.1.1/gems/rubocop-0.23.0/lib/rubocop/file_inspector.rb:114:in `mobilized_cop_classes'
/Users/ehaselwanter/.rvm/gems/ruby-2.1.1/gems/rubocop-0.23.0/lib/rubocop/file_inspector.rb:105:in `inspect_file'
/Users/ehaselwanter/.rvm/gems/ruby-2.1.1/gems/rubocop-0.23.0/lib/rubocop/file_inspector.rb:74:in `block in pr
```
