### PR TITLE
(MODULES-1189) force module install in spec_prep

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -118,6 +118,7 @@ task :spec_prep do
     next if File::exists?(target)
     unless system("puppet module install " + ref + \
                   " --ignore-dependencies" \
+                  " --force" \
                   " --target-dir spec/fixtures/modules #{remote}")
       fail "Failed to install module #{remote} to #{target}"
     end


### PR DESCRIPTION
When `puppet module install` runs it checks if the module is already installed in the modulepath. If it is it refuses to install the module even to a different target-dir.

This forces the module install to target-dir which bypasses the unnecessary check.

https://tickets.puppetlabs.com/browse/MODULES-1189
