### PR TITLE
(MODULES-1190) respect puppet-lint ignore paths in Rakefile

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -193,7 +193,8 @@ end
 desc "Check puppet manifests with puppet-lint"
 task :lint do
   require 'puppet-lint/tasks/puppet-lint'
-  PuppetLint.configuration.ignore_paths = ["spec/fixtures/**/*.pp"]
+  PuppetLint.configuration.ignore_paths ||= []
+  PuppetLint.configuration.ignore_paths << "spec/fixtures/**/*.pp"
 end
 
 desc "Check puppet manifest syntax"


### PR DESCRIPTION
Without this patch applied, the PuppetLint.configuration.ignore_paths
specified in the Rakefile is discarded in favour of the hardcoded value
provided by puppetlabs_spec_helper from v0.5.0.  This patch fixes the issue
by adding the hardcoded value to the array rather than overwriting it.
