### PR TITLE
Fix rspec 3.0 error when loading spec_helper

### DIFF
--- a/lib/puppetlabs_spec_helper/puppetlabs_spec/matchers.rb
+++ b/lib/puppetlabs_spec_helper/puppetlabs_spec/matchers.rb
@@ -1,13 +1,18 @@
 require 'stringio'
+require 'rspec/expectations'
 
 ########################################################################
 # Backward compatibility for Jenkins outdated environment.
 module RSpec
   module Matchers
     module BlockAliases
-      alias_method :to,     :should      unless method_defined? :to
-      alias_method :to_not, :should_not  unless method_defined? :to_not
-      alias_method :not_to, :should_not  unless method_defined? :not_to
+      if method_defined? :should
+        alias_method :to, :should unless method_defined? :to
+      end
+      if method_defined? :should_not
+        alias_method :to_not, :should_not unless method_defined? :to_not
+        alias_method :not_to, :should_not unless method_defined? :not_to
+      end
     end
   end
 end


### PR DESCRIPTION
Without this patch the spec helper fails to load with RSpec 3.0 because a
method that does not exist is trying to be aliased.  This is a problem because
the spec helper is incompatible with RSpec 3.0 and it would be nice to support
the latest rspec version when developing modules.

This patch addresses the problem by aliasing the methods only if they exist.
