### PR TITLE
Allow relative paths and params

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -195,9 +195,12 @@ end
 
 desc "Check puppet manifests with puppet-lint"
 task :lint do
-  require 'puppet-lint/tasks/puppet-lint'
+  require 'puppet-lint'
+  PuppetLint.configuration.relative = true
+  PuppetLint.configuration.disable_class_inherits_from_params_class
   PuppetLint.configuration.ignore_paths ||= []
   PuppetLint.configuration.ignore_paths << "spec/fixtures/**/*.pp"
+  PuppetLint.configuration.ignore_paths << "pkg/**/*.pp"
 end
 
 require 'puppet-syntax/tasks/puppet-syntax'


### PR DESCRIPTION
- The relative option allows the module directory to be something like
  `puppet-foo` which is the case for practically all automated testing.
- The params pattern is not compatible with puppet 2.6, but this lint
  issue will be removed from a future version of the style guide as it
  is no longer incorrect.
