### PR TITLE
(MODULES-1353) Correct the puppet-lint tasks path

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -195,7 +195,7 @@ end
 
 desc "Check puppet manifests with puppet-lint"
 task :lint do
-  require 'puppet-lint'
+  require 'puppet-lint/tasks/puppet-lint'
   PuppetLint.configuration.relative = true
   PuppetLint.configuration.disable_class_inherits_from_params_class
   PuppetLint.configuration.ignore_paths ||= []


### PR DESCRIPTION
See https://tickets.puppetlabs.com/browse/MODULES-1353

`rake lint` task is broken in 0.8.1.
