### PR TITLE
Run metadata-json-lint under validate rake task

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -208,13 +208,19 @@ PuppetSyntax.exclude_paths ||= []
 PuppetSyntax.exclude_paths << "spec/fixtures/**/*.pp"
 PuppetSyntax.future_parser = true if ENV['FUTURE_PARSER'] == 'yes'
 
-desc "Check syntax of Ruby files and call :syntax"
+desc "Check syntax of Ruby files and call :syntax and :metadata"
 task :validate do
   Dir['lib/**/*.rb'].each do |lib_file|
     sh "ruby -c #{lib_file}"
   end
 
   Rake::Task[:syntax].invoke
+  Rake::Task[:metadata].invoke if File.exist?('metadata.json')
+end
+
+desc "Validate metadata.json file"
+task :metadata do
+  sh "metadata-json-lint metadata.json"
 end
 
 desc "Display the list of available rake tasks"

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rspec-puppet'
   s.add_runtime_dependency 'puppet-lint'
   s.add_runtime_dependency 'puppet-syntax'
+  s.add_runtime_dependency 'metadata-json-lint'
   s.add_runtime_dependency 'rspec'
   s.add_runtime_dependency 'mocha'
 end


### PR DESCRIPTION
Validates and performs basic lint of the metadata.json file if it
exists, skipping it if not.

(cc @nibalizer)
