### PR TITLE
(MODULES-1576) Use Puppet FileSystem abstraction for symlinks to support Windows

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -88,6 +88,8 @@ end
 
 desc "Create the fixtures directory"
 task :spec_prep do
+  require 'puppet/file_system'
+
   fixtures("repositories").each do |remote, opts|
     scm = 'git'
     if opts.instance_of?(String)
@@ -107,7 +109,7 @@ task :spec_prep do
 
   FileUtils::mkdir_p("spec/fixtures/modules")
   fixtures("symlinks").each do |source, target|
-    File::exists?(target) || FileUtils::ln_sf(source, target)
+    Puppet::FileSystem::exist?(target) || Puppet::FileSystem::symlink(source, target)
   end
 
   fixtures("forge_modules").each do |remote, opts|


### PR DESCRIPTION
- FileUtils::ln_sf is equivalent to FileUtils::ln_s and
  FileUtils::symlink, which are unfortunately broken in Windows through
  at least Ruby 2.0.  In Puppet we have a FileSystem class that
  provides a similar abstraction, but fixes all of the methods that
  are broken on Ruby for Windows.
