### PR TITLE
Exclude vendor/ files

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -221,7 +221,7 @@ end
 
 require 'puppet-syntax/tasks/puppet-syntax'
 PuppetSyntax.exclude_paths ||= []
-PuppetSyntax.exclude_paths << "spec/fixtures/**/*.pp"
+PuppetSyntax.exclude_paths << "spec/fixtures/**/*"
 PuppetSyntax.future_parser = true if ENV['FUTURE_PARSER'] == 'yes'
 
 desc "Check syntax of Ruby files and call :syntax and :metadata"

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -217,11 +217,14 @@ task :lint do
   PuppetLint.configuration.ignore_paths ||= []
   PuppetLint.configuration.ignore_paths << "spec/fixtures/**/*.pp"
   PuppetLint.configuration.ignore_paths << "pkg/**/*.pp"
+  PuppetLint.configuration.ignore_paths << "vendor/**/*.pp"
 end
 
 require 'puppet-syntax/tasks/puppet-syntax'
 PuppetSyntax.exclude_paths ||= []
 PuppetSyntax.exclude_paths << "spec/fixtures/**/*"
+PuppetSyntax.exclude_paths << "pkg/**/*"
+PuppetSyntax.exclude_paths << "vendor/**/*"
 PuppetSyntax.future_parser = true if ENV['FUTURE_PARSER'] == 'yes'
 
 desc "Check syntax of Ruby files and call :syntax and :metadata"


### PR DESCRIPTION
Commit messages have more info, but this helps you use the new Travis CI bundler caching feature out of the box, which tells bundler to use vendor/ by default.

Unfortunately both puppet-syntax and lint have issues with file exclusion configuration right now, but it looks like they'll be fixed and released in due course.

* ~~https://github.com/gds-operations/puppet-syntax/pull/34~~
* https://github.com/rodjek/puppet-lint/issues/331 (and ~~https://github.com/rodjek/puppet-lint/pull/376~~)
* #80 would be needed as the config mechanism changed in puppet-lint 1.1.0