### PR TITLE
fix load issue with puppet filesystem and windows symlinks

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -93,7 +93,7 @@ task :spec_prep do
   is_windows = !!File::ALT_SEPARATOR
   puppet_symlink_available = false
   begin
-    require 'puppet/file_system'
+    require 'puppet'
     puppet_symlink_available = Puppet::FileSystem.respond_to?(:symlink)
   rescue
   end


### PR DESCRIPTION
  * previously the code was trying to load puppet/filesystem which does not exist
    or cannot be loaded.  This causes windows symlink to raise an error when it shouldn't.
    Because the LoadError is caught the functionality of detecting if the puppet symlink code
    is available fails and the patch to make symlinks work on windows never gets executed.
    By just loading puppet we can still access the puppet/filesystem code and be able to use
    windows symlinks.