### PR TITLE
Enable strict_variables by default if puppet version > 4.0

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -101,8 +101,8 @@ variables for the spec run. These are:
 * ``FUTURE_PARSER`` - set to "yes" to enable the [future parser](http://docs.puppetlabs.com/puppet/latest/reference/experiments_future.html),
   the equivalent of setting [parser=future](http://docs.puppetlabs.com/references/latest/configuration.html#parser)
   in puppet.conf.
-* ``STRICT_VARIABLES`` - set to "yes" to enable strict variable checking,
-  the equivalent of setting [strict_variables](http://docs.puppetlabs.com/references/latest/configuration.html#strictvariables)=true
+* ``STRICT_VARIABLES`` - set to "no" to disable strict variable checking when using Puppet >= 4.0,
+  the equivalent of not setting [strict_variables](http://docs.puppetlabs.com/references/latest/configuration.html#strictvariables)
   in puppet.conf.
 * ``ORDERING`` - set to the desired ordering method ("title-hash", "manifest", or "random")
   to set the order of unrelated resources when applying a catalog. Leave unset for the default

--- a/lib/puppetlabs_spec_helper/module_spec_helper.rb
+++ b/lib/puppetlabs_spec_helper/module_spec_helper.rb
@@ -38,7 +38,7 @@ RSpec.configure do |c|
       Puppet.settings[:stringify_facts] = false if ENV['STRINGIFY_FACTS'] == 'no'
       Puppet.settings[:trusted_node_data] = true if ENV['TRUSTED_NODE_DATA'] == 'yes'
     end
-    Puppet.settings[:strict_variables] = true if ENV['STRICT_VARIABLES'] == 'yes'
+    Puppet.settings[:strict_variables] = (ENV['STRICT_VARIABLES'] == 'yes' or (Puppet.version.to_f >= '4.0' and ENV['STRICT_VARIABLES'] != 'no'))
     Puppet.settings[:ordering] = ENV['ORDERING'] if ENV['ORDERING']
   end
 end


### PR DESCRIPTION
This may break a lot of tests but could bring out a lot a bugs.
Few people actually uses STRICT_VARIABLES in its matrix travis (which is bad), so let's force it...