### PR TITLE
Remove rspec dependency

### DIFF
--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -22,6 +22,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppet-lint'
   s.add_runtime_dependency 'puppet-syntax'
   s.add_runtime_dependency 'metadata-json-lint'
-  s.add_runtime_dependency 'rspec'
   s.add_runtime_dependency 'mocha'
 end


### PR DESCRIPTION
rspec does not need to be included explicitly as a dependency, as
rspec-puppet already does that.

Moreover, when rspec is added as a dependency with no version
specified, gem will attempt to install the latest version. The latest
version of rspec-puppet pins rspec to 2.x, so this causes a conflict:

```
gem install puppetlabs_spec_helper --no-ri --no-rdoc
ERROR:  While executing gem ... (Gem::DependencyError)
    Unable to resolve dependencies: rspec requires rspec-core (~> 2.99.0), rspec-expectations (~> 2.99.0), rspec-mocks (~> 2.99.0)
```

This commit fixes the dependency error by removing the explicit rspec
dependency in puppetlabs_spec_helper so it can be included by
rspec-puppet.