### PR TITLE
Remove hard dependency on json

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -236,7 +236,12 @@ end
 
 desc "Validate metadata.json file"
 task :metadata do
-  sh "metadata-json-lint metadata.json"
+  begin
+    require 'metadata_json_lint'
+    sh "metadata-json-lint metadata.json"
+  rescue LoadError => e
+    warn "Skipping metadata validation; the metadata-json-lint gem was not found"
+  end
 end
 
 desc "Display the list of available rake tasks"

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -21,6 +21,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rspec-puppet'
   s.add_runtime_dependency 'puppet-lint'
   s.add_runtime_dependency 'puppet-syntax'
-  s.add_runtime_dependency 'metadata-json-lint'
   s.add_runtime_dependency 'mocha'
 end


### PR DESCRIPTION
The metadata-json-lint gem requires json which is a native extention.
This means it requires a full dev chain to install
puppetlabs_spec_helper with this dependency.

This commit removes the dependency, but instead prints a warning when
the gem is not found but does not error.