### PR TITLE
Release 0.9.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+2015-02-24 - Release 0.9.1
+Summary:
+This release removes the hard dependency on metadata-json-lint, as it requires
+a dev toolchain to install the 'json' gem.
+
+Bugfixes:
+- Only warn when metadata-json-lint isn't installed instead of requiring it
+
 2015-02-24 - Release 0.9.0
 Summary:
 This release adds fixes for rspec-puppet 2.0 and json linting for metadata.json

--- a/lib/puppetlabs_spec_helper/version.rb
+++ b/lib/puppetlabs_spec_helper/version.rb
@@ -1,5 +1,5 @@
 module PuppetlabsSpecHelper
   module Version
-    STRING = '0.9.0'
+    STRING = '0.9.1'
   end
 end


### PR DESCRIPTION
Summary:
This release removes the hard dependency on metadata-json-lint, as it
requires a dev toolchain to install the 'json' gem.

Bugfixes:
- Only warn when metadata-json-lint isn't installed instead of requiring
  it