### PR TITLE
Only use --depth 1 if ref is not used

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -65,7 +65,7 @@ def clone_repo(scm, remote, target, ref=nil, branch=nil)
     args.push(remote, target)
   when 'git'
     args.push('clone')
-    args.push('--depth 1')
+    args.push('--depth 1') unless ref
     args.push('-b', branch) if branch
     args.push(remote, target)
   else


### PR DESCRIPTION
The use of "--depth 1" when cloning a git repo makes reseting to a tag not work.  The other option would be to execute `git fetch --tags origin` to continue supporting git cloning of specific tags.

Issue - https://tickets.puppetlabs.com/browse/MODULES-1861