### PR TITLE
(MODULES-1206) Added code coverage through SimpleCov for Ruby >= 1.9

### DIFF
--- a/lib/puppetlabs_spec_helper/module_spec_helper.rb
+++ b/lib/puppetlabs_spec_helper/module_spec_helper.rb
@@ -1,4 +1,8 @@
-if ENV['COVERAGE'] == 'SimpleCov'
+case ENV['COVERAGE']
+when 'Coveralls'
+  require 'coveralls'
+  Coveralls.wear!
+when 'SimpleCov'
   require 'simplecov'
   SimpleCov.start
 end

--- a/lib/puppetlabs_spec_helper/module_spec_helper.rb
+++ b/lib/puppetlabs_spec_helper/module_spec_helper.rb
@@ -1,3 +1,8 @@
+if ENV['COVERAGE'] == 'SimpleCov'
+  require 'simplecov'
+  SimpleCov.start
+end
+
 require 'rspec-puppet'
 require 'puppetlabs_spec_helper/puppet_spec_helper'
 require 'puppetlabs_spec_helper/puppetlabs_spec/puppet_internals'

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -17,9 +17,26 @@ RSpec::Core::RakeTask.new(:beaker) do |t|
 end
 
 desc "Generate code coverage information"
-RSpec::Core::RakeTask.new(:coverage) do |t|
-  t.rcov = true
-  t.rcov_opts = ['--exclude', 'spec']
+task :coverage do
+  if RUBY_VERSION.to_f < 1.9
+    Rake::Task['coverage:rcov'].invoke
+  else
+    Rake::Task['coverage:simplecov'].invoke
+  end
+end
+
+namespace :coverage do
+  desc "Generate code coverage information using rcov"
+  RSpec::Core::RakeTask.new(:rcov) do |t|
+    t.rcov = true
+    t.rcov_opts = ['--exclude', 'spec']
+  end
+
+  desc "Generate code coverage information using SimpleCov"
+  task :simplecov do
+    ENV['COVERAGE'] = 'SimpleCov'
+    Rake::Task[:spec].invoke
+  end
 end
 
 # This is a helper for the self-symlink entry of fixtures.yml

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -26,6 +26,12 @@ task :coverage do
 end
 
 namespace :coverage do
+  desc "Generate code coverage information using Coveralls.io"
+  task :coveralls do
+    ENV['COVERAGE'] = 'Coveralls'
+    Rake::Task[:spec].invoke
+  end
+
   desc "Generate code coverage information using rcov"
   RSpec::Core::RakeTask.new(:rcov) do |t|
     t.rcov = true

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -22,4 +22,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppet-lint'
   s.add_runtime_dependency 'puppet-syntax'
   s.add_runtime_dependency 'mocha'
+  s.add_runtime_dependency 'coveralls'
+  s.add_runtime_dependency 'simplecov'
 end


### PR DESCRIPTION
The `rake` task `:coverage` used the `rcov` gem which
> [...] __does not__ work on Ruby 1.9.x.  For coverage on Ruby 1.9 look at [SimpleCov](https://github.com/colszowka/simplecov) ([Quote](https://github.com/relevance/rcov/blob/master/README.markdown))

I fixed this by
* Renaming the `rake` task `:coverage` to `coverage:rcov`
* Adding a `rake` task `coverage:simplecov`
* Adding a `rake` task `:coverage` which calls `coverage:rcov` (Ruby < 1.9) or `coverage:simplecov` (Ruby >= 1.9) respectively

hence staying backward compatible and solving issue [MODULES-1206](https://tickets.puppetlabs.com/browse/MODULES-1206).