### PR TITLE
Updates for puppet 4

### DIFF
--- a/lib/puppetlabs_spec_helper/module_spec_helper.rb
+++ b/lib/puppetlabs_spec_helper/module_spec_helper.rb
@@ -11,7 +11,8 @@ def verify_contents(subject, title, expected_lines)
   (content.split("\n") & expected_lines).should == expected_lines
 end
 
-fixture_path = File.expand_path(File.join(Dir.pwd, 'spec/fixtures'))
+spec_path = File.expand_path(File.join(Dir.pwd, 'spec'))
+fixture_path = File.join(spec_path, 'fixtures')
 
 env_module_path = ENV['MODULEPATH']
 module_path = File.join(fixture_path, 'modules')
@@ -19,6 +20,7 @@ module_path = File.join(fixture_path, 'modules')
 module_path = [module_path, env_module_path].join(File::PATH_SEPARATOR) if env_module_path
 
 RSpec.configure do |c|
+  c.environmentpath = spec_path if Puppet.version.to_f >= 4.0
   c.module_path = module_path
   c.manifest_dir = File.join(fixture_path, 'manifests')
   c.parser = 'future' if ENV['FUTURE_PARSER'] == 'yes'

--- a/lib/puppetlabs_spec_helper/puppetlabs_spec/puppet_internals.rb
+++ b/lib/puppetlabs_spec_helper/puppetlabs_spec/puppet_internals.rb
@@ -47,7 +47,11 @@ module PuppetlabsSpec
     def node(parts = {})
       node_name = parts[:name] || 'testinghost'
       options = parts[:options] || {}
-      node_environment = Puppet::Node::Environment.new(parts[:environment] || 'test')
+      if Puppet.version.to_f >= 4.0
+        node_environment = Puppet::Node::Environment.create(parts[:environment] || 'test', [])
+      else
+        node_environment = Puppet::Node::Environment.new(parts[:environment] || 'test')
+      end
       options.merge!({:environment => node_environment})
       Puppet::Node.new(node_name, options)
     end


### PR DESCRIPTION
Puppet 4 uses the environmentpath instead of modulepath and manifest
settings. We can set environmentpath to spec/ and use an environment of
'fixtures' to get catalogs.