### PR TITLE
(MODULES-2002) Accept alternate fixtures file

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -29,7 +29,7 @@ end
 
 def fixtures(category)
   begin
-    fixtures = YAML.load_file(".fixtures.yml")["fixtures"]
+    fixtures = YAML.load_file( ENV['FIXTURES_YML'] || '.fixtures.yml' )['fixtures']
   rescue Errno::ENOENT
     return {}
   end


### PR DESCRIPTION
Without this patch, the location of the fixtures YAML file is hard-coded
to be ".fixtures.yaml."  This does not accommodate modules that are
tested across environments with different module locations.

This patch introduces an environment variable FIXTURES_YML, which can
be used to specify the location of an alternate fixtures data file.