### PR TITLE
Deprecate PuppetInternals.scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,30 +278,8 @@ Pass additional flags to module installation:
 Testing Parser Functions
 ========================
 
-This library provides a consistent way to create a Puppet::Parser::Scope object
-suitable for use in a testing harness with the intent of testing the expected
-behavior of parser functions distributed in modules.
-
-Previously, modules would do something like this:
-
-    describe "split()" do
-      let(:scope) { Puppet::Parser::Scope.new }
-      it "should split 'one;two' on ';' into [ 'one', 'two' ]" do
-        scope.function_split(['one;two', ';']).should == [ 'one', 'two' ]
-      end
-    end
-
-This will not work beyond Puppet 2.7 as we have changed the behavior of the
-scope initializer in Puppet 3.0.  Modules should instead initialize scope
-instances in a manner decoupled from the internal behavior of Puppet:
-
-    require 'puppetlabs_spec_helper/puppetlabs_spec/puppet_internals'
-    describe "split()" do
-      let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
-      it "should split 'one;two' on ';' into [ 'one', 'two' ]" do
-        scope.function_split(['one;two', ';']).should == [ 'one', 'two' ]
-      end
-    end
+This whole section is superseded by improved support of accessing the scope in
+rspec-puppet.
 
 Generating code coverage reports
 ================================

--- a/lib/puppetlabs_spec_helper/puppetlabs_spec/puppet_internals.rb
+++ b/lib/puppetlabs_spec_helper/puppetlabs_spec/puppet_internals.rb
@@ -8,6 +8,8 @@ module PuppetlabsSpec
     # instance suitable for placing in a test harness with the intent of
     # testing parser functions from modules.
     def scope(parts = {})
+      RSpec.deprecate('scope', :replacement => 'rspec-puppet 2.2.0 provides a scope property')
+
       if Puppet.version =~ /^2\.[67]/
         # loadall should only be necessary prior to 3.x
         # Please note, loadall needs to happen first when creating a scope, otherwise


### PR DESCRIPTION
rspec-puppet provides the scope it is using to call the function within the run
matcher as a property. Using that is much preferred over building our own.

This "depends" on https://github.com/rodjek/rspec-puppet/pull/301, a documentation update for rspec-puppet. 