### PR TITLE
Feature/fixture rebuild

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -289,7 +289,7 @@ task :fixture_rebuild do
     fail 'Unable to create new .fixtures.yml file'
   end
 end
-
+task :spec_prep => ['fixture_rebuild']
 
 desc "Display the list of available rake tasks"
 task :help do


### PR DESCRIPTION
Makes no sense to have to maintain two separate locations for dependencies. The fixture_rebuild task will read the dependencies from metadata.json and add them as forge_modules as to the .fixture.yml file. 
