### PR TITLE
Support loading from .fixtures.yaml too

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -28,14 +28,20 @@ def source_dir
 end
 
 def fixtures(category)
-  begin
-    fixtures = YAML.load_file(".fixtures.yml")["fixtures"]
-  rescue Errno::ENOENT
-    return {}
+  if File.exists?('.fixtures.yml')
+    fixtures_yaml = '.fixtures.yml'
+  elsif File.exists?('.fixtures.yaml')
+    fixtures_yaml = '.fixtures.yaml'
+  else
+    fixtures_yaml = ''
   end
 
-  if not fixtures
-    abort("malformed fixtures.yml")
+  begin
+    fixtures = YAML.load_file(fixtures_yaml)["fixtures"]
+  rescue Error::ENOENT
+    return {}
+  rescue Psych::SyntaxError
+    abort("malformed #{fixtures_yaml}")
   end
 
   result = {}


### PR DESCRIPTION
YAML can have multiple extensions, `.yml` and `.yaml`. Hiera has used
`.yaml` all over the place but for some reason the spec_helper gets
extremely sad (it doesn't load anything) when you have a `.fixtures.yaml`
instead. This is annoying for the end user and easily dealt with in code.

Additionally we now actually catch `Psych::SyntaxError` and abort in
that case instead of just checking for `Error::ENOENT` and returning
before. I'm not even sure if the `if not fixtures` would ever be
triggered since a syntax error would actually raise an error we
were not rescuing.