### PR TITLE
Automatically symlink the module directory

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -27,6 +27,10 @@ def source_dir
   Dir.pwd
 end
 
+def auto_symlink
+  { Dir.pwd.split('/').last.split('-').last => '#{source_dir}' }
+end
+
 def fixtures(category)
   if File.exists?('.fixtures.yml')
     fixtures_yaml = '.fixtures.yml'
@@ -39,9 +43,13 @@ def fixtures(category)
   begin
     fixtures = YAML.load_file(fixtures_yaml)["fixtures"]
   rescue Error::ENOENT
-    return {}
+    fixtures = {}
   rescue Psych::SyntaxError => e
     abort("Found malformed YAML in #{fixtures_yaml} on line #{e.line} column #{e.column}: #{e.problem}")
+  end
+
+  if fixtures['symlinks'].nil?
+    fixtures['symlinks'] = auto_symlink
   end
 
   result = {}


### PR DESCRIPTION
It's silly to require everyone to add a `source: $module_name: ${source_dir}`
to every fixtures file. This takes care of it by simply grabbing the name
of the current directory and creating the symlink stanza for you if there
isn't one.

If there's no fixtures file at all we still define the symlink
meaning that we can forego the fixtures file entirely if we do
not need to load additional modules from git/forge.

This even works when `rake` is called from subdirectories within
spec/ or any other part of the module because rake searches upwards
to find the Rakefile and executes that making `Dir.pwd` always be
reliably splittable to get the module name, unless things are not
in autoloader layout.

When this behaviour is undesired people can simply add an empty
symlinks stanza `symlinks: {}` or `symlinks: ''` instead.

I think it's far more likely that people will need to add one to
link their module than the inverse saving a lot of people some
trouble.