### PR TITLE
Add types in the rake tasks

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -7,7 +7,7 @@ task :default => [:help]
 desc "Run spec tests on an existing fixtures directory"
 RSpec::Core::RakeTask.new(:spec_standalone) do |t|
   t.rspec_opts = ['--color']
-  t.pattern = 'spec/{classes,defines,unit,functions,hosts,integration}/**/*_spec.rb'
+  t.pattern = 'spec/{classes,defines,unit,functions,hosts,integration,types}/**/*_spec.rb'
 end
 
 desc "Run beaker acceptance tests"


### PR DESCRIPTION
As documented in https://github.com/rodjek/rspec-puppet types is also a valid directory for spec tests.