### PR TITLE
Ability to split spec files across multiple CI nodes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -122,6 +122,18 @@ and manifest ordering, you would:
 
     FUTURE_PARSER=yes STRICT_VARIABLES=yes ORDERING=manifest rake spec
 
+When executing tests in a matrix CI environment, tests can be split up to run
+a share of specs per CI node in parallel.  Set the ``CI_NODE_TOTAL`` environment
+variable to the total number of nodes, and the ``CI_NODE_INDEX`` to a number
+between 1 and the ``CI_NODE_TOTAL``.
+
+If using Travis CI, add new lines to the "env" section of .travis.yml per node,
+remembering to duplicate any existing environment variables:
+
+    env:
+      - FUTURE_PARSER=yes CI_NODE_TOTAL=2 CI_NODE_INDEX=1
+      - FUTURE_PARSER=yes CI_NODE_TOTAL=2 CI_NODE_INDEX=2
+
 Using Utility Classes
 =====================
 If you'd like to use the Utility classes (PuppetlabsSpec::Files,


### PR DESCRIPTION
With many specs it can speed up tests considerably to use a CI matrix
to run tests in parallel.  This adds CI_NODE_TOTAL and CI_NODE_INDEX
environment variables to the rake spec_standalone task to run a subset
of the spec files on a single node in a simple manner.

The index variable should be added to the CI matrix, e.g. a Travis CI
"env" section or a Jenkins matrix job.

---

We're having difficulty in some of our modules particularly when testing on older Puppet and Ruby versions with [rspec-puppet-facts](https://github.com/mcanevet/rspec-puppet-facts/), so the added parallelisation should keep some of our longer suites running within Travis CI timeouts.