### PR TITLE
Should use Errno, not Error

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -38,7 +38,7 @@ def fixtures(category)
 
   begin
     fixtures = YAML.load_file(fixtures_yaml)["fixtures"]
-  rescue Error::ENOENT
+  rescue Errno::ENOENT
     return {}
   rescue Psych::SyntaxError => e
     abort("Found malformed YAML in #{fixtures_yaml} on line #{e.line} column #{e.column}: #{e.problem}")


### PR DESCRIPTION
We have a CI/CD env that automatically builds rpms from puppet modules we develop ourselves. As part of the automatic build the spec tests are performed. I noticed that after you released 1.0.0 of puppelabs_spec_helper suddenls all our spec tests started failing, all with the same error:
```
NameError: uninitialized constant Error
/var/lib/jenkins/.gem/gems/puppetlabs_spec_helper-1.0.0/lib/puppetlabs_spec_helper/rake_tasks.rb:41:in `rescue in fixtures'
/var/lib/jenkins/.gem/gems/puppetlabs_spec_helper-1.0.0/lib/puppetlabs_spec_helper/rake_tasks.rb:39:in `fixtures'
/var/lib/jenkins/.gem/gems/puppetlabs_spec_helper-1.0.0/lib/puppetlabs_spec_helper/rake_tasks.rb:111:in `block in <top (required)>'
/var/lib/jenkins/.gem/gems/puppetlabs_spec_helper-1.0.0/lib/puppetlabs_spec_helper/rake_tasks.rb:197:in `block in <top (required)>'
Tasks: TOP => spec_prep
```
I traced this to rake_tasks.rb, where I think it shoud be "Errno" and not "Error". 

Note, I'm not really a Ruby expert. This is just a hunch I had, which I managed to conform through my own testing. 