### PR TITLE
(maint) Add task to print development version

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -268,6 +268,33 @@ task :metadata do
   end
 end
 
+desc "Print development version of module"
+task :compute_dev_version do
+  version = ''
+  if File.exists?( 'metadata.json' )
+    require 'json'
+
+    modinfo = JSON.parse(File.read( 'metadata.json' ))
+    version = modinfo['version']
+  elsif File.exists?( 'Modulefile' )
+    modfile = File.read('Modulefile')
+    version = modfile.match(/\nversion[ ]+['"](.*)['"]/)[1]
+  else
+    fail "Could not find a metadata.json or Modulefile! Cannot compute dev version without one or the other!"
+  end
+
+  sha = `git rev-parse HEAD`[0..7]
+
+  # If we're in a CI environment include our build number
+  if build = ENV['BUILD_NUMBER'] || ENV['TRAVIS_BUILD_NUMBER']
+    new_version = sprintf('%s-%04d-%s', version, build, sha)
+  else
+    new_version = "#{version}-#{sha}"
+  end
+
+  print new_version
+end
+
 desc "Display the list of available rake tasks"
 task :help do
   system("rake -T")


### PR DESCRIPTION
This adds the task `compute_dev_version` to print a computed
development version of the module.

The development version is computed by appending the short sha of the
repo to the current version specified by the module. If the build is
ran in a CI environment (one with the variables BUILD_NUMBER or
TRAVIS_BUILD_NUMBER set) it will prepend the build number to the short
sha so that artifacts can easily be sorted by build numbers.

Note the printing of this dev version does not include a trailing
newline. The proposed workflow of it would be:
```
BLACKSMITH_FULL_VERSION=`bundle exec rake compute_dev_version`
export BLACKSMITH_FULL_VERSION
bundle exec rake module:bump:full
bundle exec rake module:push
```