### PR TITLE
symlinks directly to module directory dont work, this needs to be a d…

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -132,7 +132,8 @@ task :spec_prep do
       fail "Cannot symlink on Windows unless using at least Puppet 3.5" if !puppet_symlink_available
       Puppet::FileSystem::exist?(target) || Puppet::FileSystem::symlink(source, target)
     else
-      File::exists?(target) || FileUtils::ln_sf(source, target)
+      File::exists?(target) || FileUtils::mkdir_p(target)
+      File::exists?("#{target}/manifests") || FileUtils::ln_sf("#{source}/manifests", "#{target}/manifests")
     end
   end
 

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -133,7 +133,11 @@ task :spec_prep do
       Puppet::FileSystem::exist?(target) || Puppet::FileSystem::symlink(source, target)
     else
       File::exists?(target) || FileUtils::mkdir_p(target)
-      File::exists?("#{target}/manifests") || FileUtils::ln_sf("#{source}/manifests", "#{target}/manifests")
+      ['manifests','lib','files','templates'].each do |dir|
+        if File.exist? "#{source}/#{dir}"
+          File::exists?("#{target}/#{dir}") || FileUtils::ln_sf("#{source}/#{dir}", "#{target}/#{dir}")
+        end
+      end
     end
   end
 

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -184,7 +184,7 @@ task :spec_clean do
   end
 
   fixtures("symlinks").each do |source, target|
-    FileUtils::rm_f(target)
+    FileUtils::rm_rf(target)
   end
 
   if File.zero?("spec/fixtures/manifests/site.pp")


### PR DESCRIPTION
…irectory containing a symlink to the #{module_dir}/manifests dir or rspec cant locate the class

I tried to use this module on my ubuntu 14.04 laptop and on both puppetlabs/centos-6.6-64-nocm and puppetlabs/ubuntu-14.04-64-nocm vagrant images using 3 different ruby versions (and therefore 3 different sets of the puppet, rspec, rspec-puppet and friends gems) via rvm and got the same result every time, it couldnt find my class :( :

```
[vagrant@localhost openldap]$ rm -rf spec/fixtures/
[vagrant@localhost openldap]$ rake spec
/home/vagrant/.rvm/rubies/ruby-2.2.4/bin/ruby -I/home/vagrant/.rvm/gems/ruby-2.2.4/gems/rspec-support-3.4.1/lib:/home/vagrant/.rvm/gems/ruby-2.2.4/gems/
rspec-core-3.4.1/lib /home/vagrant/.rvm/gems/ruby-2.2.4/gems/rspec-core-3.4.1/exe/rspec --pattern spec/\{classes,defines,unit,functions,hosts,integratio
n,types\}/\*\*/\*_spec.rb --color
FF

Failures:

  1) openldap should compile into a catalogue without dependency cycles
     Failure/Error: it { is_expected.to compile.with_all_deps }
       error during compilation: Evaluation Error: Error while evaluating a Function Call, Could not find class ::openldap for localhost.cequint.local a
t line 1:1 on node localhost.cequint.local
     # ./spec/classes/openldap__client_spec.rb:4:in `block (2 levels) in <top (required)>'

  2) openldap should contain Package[openldap-clients] with ensure => :present
     Failure/Error:
        it { is_expected.to contain_package('openldap-clients').with(
         {
           :ensure => :present,
         }
       ) }
     
     Puppet::PreformattedError:
       Evaluation Error: Error while evaluating a Function Call, Could not find class ::openldap for localhost.cequint.local at line 1:1 on node localho
st.cequint.local
     # /home/vagrant/.rvm/gems/ruby-2.2.4/gems/puppet-4.3.1/lib/puppet/parser/compiler.rb:388:in `block in evaluate_classes'
     # /home/vagrant/.rvm/gems/ruby-2.2.4/gems/puppet-4.3.1/lib/puppet/parser/compiler.rb:387:in `collect'
     # /home/vagrant/.rvm/gems/ruby-2.2.4/gems/puppet-4.3.1/lib/puppet/parser/compiler.rb:387:in `evaluate_classes'
     # /home/vagrant/.rvm/gems/ruby-2.2.4/gems/puppet-4.3.1/lib/puppet/parser/functions/include.rb:33:in `block in <top (required)>'
     # /home/vagrant/.rvm/gems/ruby-2.2.4/gems/puppet-4.3.1/lib/puppet/parser/functions.rb:162:in `block (2 levels) in newfunction'
     # /home/vagrant/.rvm/gems/ruby-2.2.4/gems/puppet-4.3.1/lib/puppet/util/profiler/around_profiler.rb:58:in `profile'
     # /home/vagrant/.rvm/gems/ruby-2.2.4/gems/puppet-4.3.1/lib/puppet/util/profiler.rb:51:in `profile'
     # /home/vagrant/.rvm/gems/ruby-2.2.4/gems/puppet-4.3.1/lib/puppet/parser/functions.rb:155:in `block in newfunction'
     # /home/vagrant/.rvm/gems/ruby-2.2.4/gems/puppet-4.3.1/lib/puppet/pops/evaluator/runtime3_support.rb:281:in `call_function'
     # /home/vagrant/.rvm/gems/ruby-2.2.4/gems/puppet-4.3.1/lib/puppet/pops/evaluator/evaluator_impl.rb:840:in `call_function_with_block'
     # /home/vagrant/.rvm/gems/ruby-2.2.4/gems/puppet-4.3.1/lib/puppet/pops/evaluator/evaluator_impl.rb:820:in `eval_CallNamedFunctionExpression'
     # /home/vagrant/.rvm/gems/ruby-2.2.4/gems/puppet-4.3.1/lib/puppet/pops/visitor.rb:67:in `visit_this_1'
     # /home/vagrant/.rvm/gems/ruby-2.2.4/gems/puppet-4.3.1/lib/puppet/pops/evaluator/evaluator_impl.rb:73:in `evaluate'
...
```

The following is created for the fixtures:
```
[vagrant@localhost openldap]$ tree spec/fixtures/
spec/fixtures/
├── manifests
│   └── site.pp
└── modules
    └── openldap -> /opt/puppet/openldap

3 directories, 1 file
```

With the patch:
```
[vagrant@localhost openldap]$ rm -rf spec/fixtures
[vagrant@localhost openldap]$ rake spec                                                                                                                 
/home/vagrant/.rvm/rubies/ruby-2.2.4/bin/ruby -I/home/vagrant/.rvm/gems/ruby-2.2.4/gems/rspec-support-3.4.1/lib:/home/vagrant/.rvm/gems/ruby-2.2.4/gems/rspec-core-3.4.1/lib /home/vagrant/.rvm/gems/ruby-2.2.4/gems/rspec-core-3.4.1/exe/rspec --pattern spec/\{classes,defines,unit,functions,hosts,integration,types\}/\*\*/\*_spec.rb --color
..

Finished in 1.35 seconds (files took 0.91958 seconds to load)
2 examples, 0 failures
```

And we see the following fs structure created:
```
[vagrant@localhost openldap]$ tree spec/fixtures
spec/fixtures
├── manifests
└── modules
    └── openldap
        └── manifests -> /opt/puppet/openldap/manifests

4 directories, 0 files
```

Once that structure has been created, the original code works normally so perhaps folks are using skeleton generators that create the spec/fixture directories so this isnt getting hit? Or maybe there is a fancier .fixtures.yaml file to use than this?:
```
[vagrant@localhost openldap]$ cat .fixtures.yml 
fixtures:
  symlinks:
    openldap: "#{source_dir}"
```

Anyway, just `rm -rf spec/fixtures`  and do a `rake spec` to repo this issue.
