### PR TITLE
MODULES-3127  Remove deprecated 'should' syntax

### DIFF
--- a/lib/puppetlabs_spec_helper/module_spec_helper.rb
+++ b/lib/puppetlabs_spec_helper/module_spec_helper.rb
@@ -8,7 +8,7 @@ end
 
 def verify_contents(subject, title, expected_lines)
   content = subject.resource('file', title).send(:parameters)[:content]
-  (content.split("\n") & expected_lines).should == expected_lines
+  expect(content.split("\n") & expected_lines).to eql expected_lines
 end
 
 spec_path = File.expand_path(File.join(Dir.pwd, 'spec'))


### PR DESCRIPTION
Without this patch applied, a deprecation warning is seen when the
verify_contents method is called in module_spec_helper.