### PR TITLE
[MODULES-3128] Ignore symlinks inside .git when running check:symlinks rake task

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -394,7 +394,7 @@ end
 namespace :check do
   desc "Fails if symlinks are present in directory"
   task :symlinks do
-    symlink = `find . -type l -ls`
+    symlink = `find . -path ./.git -prune -o -type l -ls`
     unless symlink == ""
       puts symlink
       fail "A symlink exists within this directory"


### PR DESCRIPTION
Fix for MODULES-3128

Before this change rake check:symlinks would search for symlinks
anywhere within the project directory. This meant that using symlinks to
install git hooks would trigget an error (false possitive).

This change modifies the check:symlinks task to exclude the .git
directory from the check:symlinks search
