### PR TITLE
Remove obsolete code from module build task

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -287,16 +287,10 @@ task :beaker_nodes do
   }
 end
 
-desc "Build puppet module package"
+desc 'Build puppet module package'
 task :build do
-  # This will be deprecated once puppet-module is a face.
-  begin
-    Gem::Specification.find_by_name('puppet-module')
-  rescue Gem::LoadError, NoMethodError
-    require 'puppet/face'
-    pmod = Puppet::Face['module', :current]
-    pmod.build('./')
-  end
+  require 'puppet/face'
+  Puppet::Face['module', :current].build('./')
 end
 
 desc "Clean a built module package"


### PR DESCRIPTION
Remove obsolete call to the `puppet-module` gem, which
"moved into core as of Puppet 2.7.12 and will no longer be maintained".
(https://github.com/puppetlabs/puppet-module-tool)