### PR TITLE
Update spec tests to RSpec 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'puppet-syntax'
 gem 'mocha'
 
 group :development do
+  gem 'rspec', '~> 3'
   gem 'yard'
   gem 'pry'
   gem 'jeweler'

--- a/spec/lib/puppet/type/spechelper.rb
+++ b/spec/lib/puppet/type/spechelper.rb
@@ -1,6 +1,0 @@
-require 'puppet/type'
-
-Puppet::Type.newtype(:spechelper) do
-  @doc = "This is the spechelper type"
-end
-

--- a/spec/unit/puppetlabs_spec_helper/puppetlabs_spec/puppet_internals_spec.rb
+++ b/spec/unit/puppetlabs_spec_helper/puppetlabs_spec/puppet_internals_spec.rb
@@ -2,90 +2,100 @@ require 'spec_helper'
 require 'puppetlabs_spec_helper/puppet_spec_helper'
 require 'puppetlabs_spec_helper/puppetlabs_spec/puppet_internals'
 
+RSpec.configure do |c|
+  c.mock_with :rspec
+end
+
 describe PuppetlabsSpec::PuppetInternals do
   before(:all) do
     Puppet.initialize_settings
   end
-  describe ".scope" do
-    it "should return a Puppet::Parser::Scope instance" do
-      subject.scope.should be_a_kind_of Puppet::Parser::Scope
+
+  describe '.scope' do
+    let(:subject) { described_class.scope }
+
+    it 'should return a Puppet::Parser::Scope instance' do
+      expect(subject).to be_a_kind_of Puppet::Parser::Scope
     end
 
-    xit "should be suitable for function testing" do
+    it 'should be suitable for function testing' do
       # split is now a puppet 4x core function
-      subject.scope.function_split(["one;two", ";"]).should == [ 'one', 'two' ]
+      expect(subject.function_split(['one;two', ';'])).to eq(%w(one two))
     end
 
-    it "should accept a compiler" do
-      compiler = subject.compiler
-      scope = subject.scope(:compiler => compiler)
-      scope.compiler.should == compiler
+    it 'should accept a compiler' do
+      compiler = described_class.compiler
+      scope = described_class.scope(compiler: compiler)
+      expect(scope.compiler).to eq(compiler)
     end
 
-    it "should have a source set" do
-      scope = subject.scope
-      scope.source.should_not be_nil
-      scope.source.name.should eq('foo')
-    end
-  end
-
-  describe ".resource" do
-    it "can have a defined type" do
-      subject.resource(:type => :node).type.should == :node
-    end
-
-    it "defaults to a type of hostclass" do
-      subject.resource.type.should == :hostclass
-    end
-
-    it "can have a defined name" do
-      subject.resource(:name => "testingrsrc").name.should == "testingrsrc"
-    end
-
-    it "defaults to a name of testing" do
-      subject.resource.name.should == "testing"
+    it 'should have a source set' do
+      scope = subject
+      expect(scope.source).not_to be_nil
+      expect(scope.source.name).to eq('foo')
     end
   end
 
-  describe ".compiler" do
-    let(:node) { subject.node }
+  describe '.resource' do
+    let(:subject) { described_class.resource }
 
-    it "can have a defined node" do
-      subject.compiler(:node => node).node.should be node
+    it 'can have a defined type' do
+      expect(described_class.resource(type: :node).type).to eq(:node)
+    end
+
+    it 'defaults to a type of hostclass' do
+      expect(subject.type).to eq(:hostclass)
+    end
+
+    it 'can have a defined name' do
+      expect(described_class.resource(name: 'testingrsrc').name).to eq('testingrsrc')
+    end
+
+    it 'defaults to a name of testing' do
+      expect(subject.name).to eq('testing')
     end
   end
 
-  describe ".node" do
-    it "can have a defined name" do
-      subject.node(:name => "mine").name.should == "mine"
-    end
+  describe '.compiler' do
+    let(:node) { described_class.node }
 
-    it "can have a defined environment" do
-      subject.node(:environment => "mine").environment.name.should == :mine
-    end
-
-    it "defaults to a name of testinghost" do
-      subject.node.name.should == "testinghost"
-    end
-
-    it "accepts facts via options for rspec-puppet" do
-      fact_values = { 'fqdn' => "jeff.puppetlabs.com" }
-      node = subject.node(:options => { :parameters => fact_values })
-      node.parameters.should == fact_values
+    it 'can have a defined node' do
+      expect(described_class.compiler(node: node).node).to be node
     end
   end
 
-  describe ".function_method" do
-    it "accepts an injected scope" do
-      Puppet::Parser::Functions.expects(:function).with("my_func").returns(true)
-      scope = mock()
+  describe '.node' do
+    it 'can have a defined name' do
+      expect(described_class.node(name: 'mine').name).to eq('mine')
+    end
+
+    it 'can have a defined environment' do
+      expect(described_class.node(environment: 'mine').environment.name).to eq(:mine)
+    end
+
+    it 'defaults to a name of testinghost' do
+      expect(described_class.node.name).to eq('testinghost')
+    end
+
+    it 'accepts facts via options for rspec-puppet' do
+      fact_values = { 'fqdn' => 'jeff.puppetlabs.com' }
+      node = described_class.node(options: { parameters: fact_values })
+      expect(node.parameters).to eq(fact_values)
+    end
+  end
+
+  describe '.function_method' do
+    it 'accepts an injected scope' do
+      expect(Puppet::Parser::Functions).to receive(:function).with('my_func').and_return(true)
+      scope = double(described_class.scope)
       scope.expects(:method).with(:function_my_func).returns(:fake_method)
-      subject.function_method("my_func", :scope => scope).should == :fake_method
+      expect(described_class.function_method('my_func', scope: scope)).to eq(:fake_method)
     end
+
     it "returns nil if the function doesn't exist" do
-      Puppet::Parser::Functions.expects(:function).with("my_func").returns(false)
-      scope = mock()
-      subject.function_method("my_func", :scope => scope).should be_nil
+      Puppet::Parser::Functions.expects(:function).with('my_func').returns(false)
+      scope = double(described_class.scope)
+      expect(described_class.function_method('my_func', scope: scope)).to be_nil
     end
   end
 end


### PR DESCRIPTION
- Enabled a pending test where `it` was mistyped as `xit`
- Updated syntax to Ruby 1.9 and RuboCop suggestions
- Updated syntax to RSpec 3
- Removed obsolete spec file for undefined resource type `spechelper`