### PR TITLE
Add RuboCop to both gem and module rake tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rake'
 gem 'rspec-puppet'
+gem 'rubocop'
 gem 'puppet-lint'
 gem 'puppet-syntax'
 gem 'mocha'

--- a/Rakefile
+++ b/Rakefile
@@ -46,5 +46,8 @@ end
 
 task :default => :spec
 
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new
+
 require 'yard'
 YARD::Rake::YardocTask.new

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -1,5 +1,6 @@
 require 'rake'
 require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 require 'yaml'
 
 # optional gems
@@ -303,6 +304,8 @@ desc "Clean a built module package"
 task :clean do
   FileUtils.rm_rf("pkg/")
 end
+
+RuboCop::RakeTask.new
 
 require 'puppet-lint/tasks/puppet-lint'
 # Must clear as it will not override the existing puppet-lint rake task since we require to import for

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -55,6 +55,7 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<rake>, [">= 0"])
       s.add_runtime_dependency(%q<rspec-puppet>, [">= 0"])
+      s.add_runtime_dependency(%q<rubocop>, [">= 0"])
       s.add_runtime_dependency(%q<puppet-lint>, [">= 0"])
       s.add_runtime_dependency(%q<puppet-syntax>, [">= 0"])
       s.add_runtime_dependency(%q<mocha>, [">= 0"])
@@ -65,6 +66,7 @@ Gem::Specification.new do |s|
     else
       s.add_dependency(%q<rake>, [">= 0"])
       s.add_dependency(%q<rspec-puppet>, [">= 0"])
+      s.add_dependency(%q<rubocop>, [">= 0"])
       s.add_dependency(%q<puppet-lint>, [">= 0"])
       s.add_dependency(%q<puppet-syntax>, [">= 0"])
       s.add_dependency(%q<mocha>, [">= 0"])
@@ -76,6 +78,7 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<rake>, [">= 0"])
     s.add_dependency(%q<rspec-puppet>, [">= 0"])
+    s.add_dependency(%q<rubocop>, [">= 0"])
     s.add_dependency(%q<puppet-lint>, [">= 0"])
     s.add_dependency(%q<puppet-syntax>, [">= 0"])
     s.add_dependency(%q<mocha>, [">= 0"])


### PR DESCRIPTION
This project has been describe as [dogfood](https://github.com/puppetlabs/puppet/blob/d2199af906fa5ca19ec0c37c82794934ea4fb4b5/spec/spec_helper.rb#L2) and its code is somewhat unclean and not easily comprehensible.

As a first countermeasure I suggest to add RuboCop to the project as well as all modules using this gem.