### PR TITLE
Set module_working_dir to be inside spec/fixtures

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -231,6 +231,7 @@ task :spec_prep do
     command = "puppet module install" + ref + flags + \
       " --ignore-dependencies" \
       " --force" \
+      " --module_working_dir spec/fixtures/module-working-dir" \
       " --target-dir spec/fixtures/modules #{remote}"
 
     unless system(command)
@@ -261,6 +262,8 @@ task :spec_clean do
     end
     FileUtils::rm_rf(target)
   end
+
+  FileUtils::rm_rf("spec/fixtures/module-working-dir")
 
   fixtures("symlinks").each do |source, target|
     FileUtils::rm_f(target)


### PR DESCRIPTION
This commit changes the directory `puppet module install` will use
internally when downloading forge modules.

With this change, multiple instances of `spec_prep` can be run on the
same box (eg a jenkins CI server), at the same time.  This is unreliable
if all `puppet module install` processes share the same directory.