### PR TITLE
Remove RuboCop to fix spec testing on Ruby 1.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'rake'
 gem 'rspec-puppet'
-gem 'rubocop'
 gem 'puppet-lint'
 gem 'puppet-syntax'
 gem 'mocha'

--- a/Rakefile
+++ b/Rakefile
@@ -46,8 +46,5 @@ end
 
 task :default => :spec
 
-require 'rubocop/rake_task'
-RuboCop::RakeTask.new
-
 require 'yard'
 YARD::Rake::YardocTask.new

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -1,6 +1,5 @@
 require 'rake'
 require 'rspec/core/rake_task'
-require 'rubocop/rake_task'
 require 'yaml'
 
 # optional gems
@@ -370,8 +369,6 @@ desc "Clean a built module package"
 task :clean do
   FileUtils.rm_rf("pkg/")
 end
-
-RuboCop::RakeTask.new
 
 require 'puppet-lint/tasks/puppet-lint'
 # Must clear as it will not override the existing puppet-lint rake task since we require to import for

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["Puppet Labs"]
-  s.date = "2016-03-02"
+  s.date = "2016-04-18"
   s.description = "Contains rake tasks and a standard spec_helper for running spec tests on puppet modules"
   s.email = ["modules-dept@puppetlabs.com"]
   s.extra_rdoc_files = [
@@ -39,14 +39,13 @@ Gem::Specification.new do |s|
     "puppet_spec_helper.rb",
     "puppetlabs_spec_helper.gemspec",
     "puppetlabs_spec_helper.rb",
-    "spec/lib/puppet/type/spechelper.rb",
     "spec/spec_helper.rb",
     "spec/unit/puppetlabs_spec_helper/puppetlabs_spec/puppet_internals_spec.rb",
     "spec/watchr.rb"
   ]
   s.homepage = "http://github.com/puppetlabs/puppetlabs_spec_helper"
   s.licenses = ["Apache-2.0"]
-  s.rubygems_version = "2.4.5.1"
+  s.rubygems_version = "2.2.2"
   s.summary = "Standard tasks and configuration for module spec tests"
 
   if s.respond_to? :specification_version then
@@ -55,10 +54,10 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<rake>, [">= 0"])
       s.add_runtime_dependency(%q<rspec-puppet>, [">= 0"])
-      s.add_runtime_dependency(%q<rubocop>, [">= 0"])
       s.add_runtime_dependency(%q<puppet-lint>, [">= 0"])
       s.add_runtime_dependency(%q<puppet-syntax>, [">= 0"])
       s.add_runtime_dependency(%q<mocha>, [">= 0"])
+      s.add_development_dependency(%q<rspec>, ["~> 3"])
       s.add_development_dependency(%q<yard>, [">= 0"])
       s.add_development_dependency(%q<pry>, [">= 0"])
       s.add_development_dependency(%q<jeweler>, [">= 0"])
@@ -66,10 +65,10 @@ Gem::Specification.new do |s|
     else
       s.add_dependency(%q<rake>, [">= 0"])
       s.add_dependency(%q<rspec-puppet>, [">= 0"])
-      s.add_dependency(%q<rubocop>, [">= 0"])
       s.add_dependency(%q<puppet-lint>, [">= 0"])
       s.add_dependency(%q<puppet-syntax>, [">= 0"])
       s.add_dependency(%q<mocha>, [">= 0"])
+      s.add_dependency(%q<rspec>, ["~> 3"])
       s.add_dependency(%q<yard>, [">= 0"])
       s.add_dependency(%q<pry>, [">= 0"])
       s.add_dependency(%q<jeweler>, [">= 0"])
@@ -78,10 +77,10 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<rake>, [">= 0"])
     s.add_dependency(%q<rspec-puppet>, [">= 0"])
-    s.add_dependency(%q<rubocop>, [">= 0"])
     s.add_dependency(%q<puppet-lint>, [">= 0"])
     s.add_dependency(%q<puppet-syntax>, [">= 0"])
     s.add_dependency(%q<mocha>, [">= 0"])
+    s.add_dependency(%q<rspec>, ["~> 3"])
     s.add_dependency(%q<yard>, [">= 0"])
     s.add_dependency(%q<pry>, [">= 0"])
     s.add_dependency(%q<jeweler>, [">= 0"])


### PR DESCRIPTION
Ruby 1.8 is deprecated, but is still supported by PE 3.8 which is still maintained.
As @alexjfisher pointed out in the discussion following up the merge of PR #140,
RuboCop (or at least one of its dependencies) is not compatible with Ruby 1.8.
Hence spec testing on Ruby 1.8 will break because `bundle install` fails.

Since the GemSpec is generated with Jeweler which does not support different
gem dependencies for different Ruby versions, I suggest remove RuboCop for the moment.