### PR TITLE
Accurate 'spec' description

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -315,7 +315,7 @@ task :spec_clean do
 
 end
 
-desc "Run spec tests in a clean fixtures directory"
+desc "Run spec tests and clean the fixtures directory if successful"
 task :spec do
   Rake::Task[:spec_prep].invoke
   Rake::Task[:spec_standalone].invoke


### PR DESCRIPTION
It bothers me that the description says `:spec` is run against a clean fixtures directory. It does not run `:spec_clean` first, so if your fixtures are even partially populated, the description is misleading.. Either the description should be updated, or `:spec_clean` should be run first and last. I do not believe that the behavior change would be desired by most users, though. Instead, the description has been updated for accuracy.