### PR TITLE
(maint) Fix default disable checks for puppet-lint 2.0.0

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -385,6 +385,7 @@ PuppetLint::RakeTask.new(:lint) do |config|
   config.fail_on_warnings = true
   config.disable_checks = [
     '80chars',
+    '140chars',
     'class_inherits_from_params_class',
     'class_parameter_defaults',
     'documentation',


### PR DESCRIPTION
There was a breaking change in puppet-lint 2.0.0 which renamed the
line length check from 80 to 140 chars.  This commit updates the gem
to include this newly named check.