### PR TITLE
Add a new repository fixture option

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,13 +225,13 @@ Specify that the git tag `2.4.2` of `stdlib' should be checked out:
       symlinks:
         my_module: "#{source_dir}"
 
-Move content of `manifests` directory to the root:
+Move manifests and siblings to root directory when they are inside a `code` directory:
 
     fixtures:
       repositories:
         stdlib:
-          repo: "git://github.com/puppetlabs/puppetlabs-stdlib"
-          subdir: "manifests"
+          repo: "git://github.com/puppetlabs/puppetlabs-extradirectory"
+          subdir: "code"
         
 Install modules from Puppet Forge:
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ When specifying the repo source of the fixture you have a few options as to whic
    scm: hg
    ```
  * target - the directory name to clone the repo into ie. `target: mymodule`  defaults to the repo name  (Optional)
+ * subdir - directory to be removed from the cloned repo. Its contents will be moved to the root directory (Optional)
  * ref - used to specify the tag name like version hash of commit (Optional)
    ```yaml
    ref: 1.0.0
@@ -224,6 +225,14 @@ Specify that the git tag `2.4.2` of `stdlib' should be checked out:
       symlinks:
         my_module: "#{source_dir}"
 
+Move content of `manifests` directory to the root:
+
+    fixtures:
+      repositories:
+        stdlib:
+          repo: "git://github.com/puppetlabs/puppetlabs-stdlib"
+          subdir: "manifests"
+        
 Install modules from Puppet Forge:
 
     fixtures:

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -143,15 +143,15 @@ def clone_repo(scm, remote, target, subdir=nil, ref=nil, branch=nil, flags = nil
     fail "Unfortunately #{scm} is not supported yet"
   end
   result = system("#{scm} #{args.flatten.join ' '}")
+  unless File::exists?(target)
+    fail "Failed to clone #{scm} repository #{remote} into #{target}"
+  end
   unless subdir.nil?
     Dir.mktmpdir {|tmpdir|
        FileUtils.mv(Dir.glob("#{target}/#{subdir}/{.[^\.]*,*}"), tmpdir)
        FileUtils.rm_rf("#{target}/#{subdir}")
        FileUtils.mv(Dir.glob("#{tmpdir}/{.[^\.]*,*}"), "#{target}")
     }
-  end
-  unless File::exists?(target)
-    fail "Failed to clone #{scm} repository #{remote} into #{target}"
   end
   result
 end


### PR DESCRIPTION
We were getting some errors as the structure of our repositories includes an extra directory. Given this, we needed a way to get rid of this directory moving all its contents to the root directory. With the new fixture, you can specify this extra directory and all the contents will me moved.