### PR TITLE
Correction to verify_contents method

### DIFF
--- a/lib/puppetlabs_spec_helper/module_spec_helper.rb
+++ b/lib/puppetlabs_spec_helper/module_spec_helper.rb
@@ -8,7 +8,7 @@ end
 
 def verify_contents(subject, title, expected_lines)
   content = subject.resource('file', title).send(:parameters)[:content]
-  expect(content.split("\n") & expected_lines).to eql expected_lines
+  expect(content.split("\n") & expected_lines).to match_array expected_lines.uniq
 end
 
 spec_path = File.expand_path(File.join(Dir.pwd, 'spec'))


### PR DESCRIPTION
Without this patch applied, the verify_contents method fails when the
array of lines contains duplicates.

In the expectation:

    expect(content.split("\n") & expected_lines).to eql expected_lines

The Array Intersection (&) of content & expected_lines causes duplicates
to be removed on the left-hand side, but not on the right-hand side,
leading to false negatives when expected_lines contains duplicates.

Furthermore, use of the eql matcher is incorrect; we expect the array on
the left-hand side to contain the same elements as on the right-hand
side, whereas the Array Intersection can cause the ordering to change.
    
The fix is to remove duplicates from the right-hand side as well, and
switch to the array_match matcher.