### PR TITLE
Only set strict_variables setting when required

### DIFF
--- a/lib/puppetlabs_spec_helper/module_spec_helper.rb
+++ b/lib/puppetlabs_spec_helper/module_spec_helper.rb
@@ -32,7 +32,7 @@ RSpec.configure do |c|
       Puppet.settings[:stringify_facts] = false if ENV['STRINGIFY_FACTS'] == 'no'
       Puppet.settings[:trusted_node_data] = true if ENV['TRUSTED_NODE_DATA'] == 'yes'
     end
-    Puppet.settings[:strict_variables] = (ENV['STRICT_VARIABLES'] == 'yes' or (Puppet.version.to_f >= 4.0 and ENV['STRICT_VARIABLES'] != 'no'))
+    Puppet.settings[:strict_variables] = true if ENV['STRICT_VARIABLES'] == 'yes' || (Puppet.version.to_f >= 4.0 && ENV['STRICT_VARIABLES'] != 'no')
     Puppet.settings[:ordering] = ENV['ORDERING'] if ENV['ORDERING']
   end
 end


### PR DESCRIPTION
Older Puppet versions (< 3.5) fail when trying to disable the
strict_variables setting that doesn't exist, preventing any tests from
running.

    ArgumentError:
      Attempt to assign a value to unknown configuration parameter :strict_variables
    # puppet-3.4.3/lib/puppet/settings.rb:786:in `set_value'
    # puppet-3.4.3/lib/puppet/settings.rb:109:in `[]='
    # puppetlabs_spec_helper-1.2.1/lib/puppetlabs_spec_helper/module_spec_helper.rb:35:in `block (2 levels) in <top (required)>'