### PR TITLE
(maint) Module install - ensure paths use /

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -292,11 +292,17 @@ task :spec_prep do
     end
     next if File::exists?(target)
 
+    # https://tickets.puppetlabs.com/browse/PUP-4884
+    working_dir = File.expand_path('spec/fixtures/work-dir')
+    working_dir = working_dir.gsub(/\\/, '/')
+    target_dir = File.expand_path('spec/fixtures/modules')
+    target_dir = target_dir.gsub(/\\/, '/')
+
     command = "puppet module install" + ref + flags + \
       " --ignore-dependencies" \
       " --force" \
-      " --module_working_dir spec/fixtures/module-working-dir" \
-      " --target-dir spec/fixtures/modules #{remote}"
+      " --module_working_dir #{working_dir}" \
+      " --target-dir #{target_dir} #{remote}"
 
     unless system(command)
       fail "Failed to install module #{remote} to #{target}"

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -292,11 +292,11 @@ task :spec_prep do
     end
     next if File::exists?(target)
 
-    # https://tickets.puppetlabs.com/browse/PUP-4884
+    # The problem with the relative path is that PMT doesn't expand the path properly and so passing in a relative path here
+    # becomes something like C:\somewhere\backslashes/spec/fixtures/work-dir on Windows, and then PMT barfs itself.
+    # This has been reported as https://tickets.puppetlabs.com/browse/PUP-4884
     working_dir = File.expand_path('spec/fixtures/work-dir')
-    working_dir = working_dir.gsub(/\\/, '/')
     target_dir = File.expand_path('spec/fixtures/modules')
-    target_dir = target_dir.gsub(/\\/, '/')
 
     command = "puppet module install" + ref + flags + \
       " --ignore-dependencies" \


### PR DESCRIPTION
Due to https://tickets.puppetlabs.com/browse/PUP-4884, modules
may fail to install on Windows. It's also somewhat hard to detect
this is occurring. Grab the full path every time for install and
ensure that the paths use forward slashes only.

cc @puppetlabs/modules 