### PR TITLE
(FM-5989) add i18n tools

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -15,6 +15,16 @@ task :default => [:help]
 
 pattern = 'spec/{aliases,classes,defines,unit,functions,hosts,integration,types}/**/*_spec.rb'
 
+spec = Gem::Specification.find_by_name 'gettext-setup'
+load "#{spec.gem_dir}/lib/tasks/gettext.rake"
+locales_dir = File.absolute_path('locales', File.dirname(__FILE__))
+# Initialization requires a valid locales directory
+if File.exist? locales_dir
+  GettextSetup.initialize(locales_dir)
+else
+  puts "No 'locales' directory found in #{File.dirname(__FILE__)}, skipping gettext initialization"
+end
+
 desc "Run spec tests on an existing fixtures directory"
 RSpec::Core::RakeTask.new(:spec_standalone) do |t|
   t.rspec_opts = ['--color']

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "yard"
+  spec.add_development_dependency "gettext-setup", "~> 0.13"
 end


### PR DESCRIPTION
Part of i18n and l10n of modules will be making the correct tools
available to every module. This commit:
- Adds gettext-setup gem dependency ~> 0.13
- Adds and initializes rake tasks from the gem, depdendent on the
  presence of a "locales" directory.