### PR TITLE
(MODULES-4394) Make the module_working_dir configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ Using Fixtures
 `rake spec_prep` is run. To do so, all required modules should be listed in a
 file named `.fixtures.yml` in the root of the project. You can specify a alternate location for that file in the `FIXTURES_YML` environment variable.
 
+You can use the `MODULE_WORKING_DIR` environment variable to specify a diffent location when installing module fixtures via the forge. By default the
+working directory is `<module directory>/spec/fixtures/work-dir`.
+
 When specifying the repo source of the fixture you have a few options as to which revision of the codebase you wish to use.
 
  * repo - the url to the repo

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -205,6 +205,13 @@ def logger
   @logger
 end
 
+def module_working_directory
+  # The problem with the relative path is that PMT doesn't expand the path properly and so passing in a relative path here
+  # becomes something like C:\somewhere\backslashes/spec/fixtures/work-dir on Windows, and then PMT barfs itself.
+  # This has been reported as https://tickets.puppetlabs.com/browse/PUP-4884
+  File.expand_path(ENV['MODULE_WORKING_DIR'] ? ENV['MODULE_WORKING_DIR'] : 'spec/fixtures/work-dir')
+end
+
 # returns the current thread count that is currently active
 # a status of false or nil means the thread completed
 # so when anything else we count that as a active thread
@@ -302,10 +309,7 @@ task :spec_prep do
     end
     next if File::exists?(target)
 
-    # The problem with the relative path is that PMT doesn't expand the path properly and so passing in a relative path here
-    # becomes something like C:\somewhere\backslashes/spec/fixtures/work-dir on Windows, and then PMT barfs itself.
-    # This has been reported as https://tickets.puppetlabs.com/browse/PUP-4884
-    working_dir = File.expand_path('spec/fixtures/work-dir')
+    working_dir = module_working_directory
     target_dir = File.expand_path('spec/fixtures/modules')
 
     command = "puppet module install" + ref + flags + \
@@ -343,7 +347,7 @@ task :spec_clean do
     FileUtils::rm_rf(target)
   end
 
-  FileUtils::rm_rf("spec/fixtures/module-working-dir")
+  FileUtils::rm_rf(module_working_directory)
 
   fixtures("symlinks").each do |source, target|
     FileUtils::rm_f(target)


### PR DESCRIPTION
Previously the module_work_dir used when installing modules fixtures via the
forge used a hardcoded relative path inside of the module.  However during CI
testing this path gets very long and in some instances on Windows, the fixtures
fail to install.  This commit adds support for an environment variable called
`MODULE_WORKING_DIR` which can be set and will instruct the helper to use this
user set directory.  This commit preserves converting the path into a Puppet
compatible string due to PUP-4884.  If the environment variable is not set the
current default of `spec/fixtures/work-dir` is used.