### PR TITLE
Skip gettext initialization if gem is missing

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -15,14 +15,18 @@ task :default => [:help]
 
 pattern = 'spec/{aliases,classes,defines,unit,functions,hosts,integration,type_aliases,types}/**/*_spec.rb'
 
-spec = Gem::Specification.find_by_name 'gettext-setup'
-load "#{spec.gem_dir}/lib/tasks/gettext.rake"
-locales_dir = File.absolute_path('locales', File.dirname(__FILE__))
-# Initialization requires a valid locales directory
-if File.exist? locales_dir
-  GettextSetup.initialize(locales_dir)
-else
-  puts "No 'locales' directory found in #{File.dirname(__FILE__)}, skipping gettext initialization"
+begin
+  spec = Gem::Specification.find_by_name 'gettext-setup'
+  load "#{spec.gem_dir}/lib/tasks/gettext.rake"
+  locales_dir = File.absolute_path('locales', File.dirname(__FILE__))
+  # Initialization requires a valid locales directory
+  if File.exist? locales_dir
+    GettextSetup.initialize(locales_dir)
+  else
+    puts "No 'locales' directory found in #{File.dirname(__FILE__)}, skipping gettext initialization"
+  end
+rescue Gem::LoadError
+  puts "No gettext-setup gem found, skipping gettext initialization"
 end
 
 desc "Run spec tests on an existing fixtures directory"


### PR DESCRIPTION
gettext-setup is marked as a development dependency, so treat it as
optional since test installations may exclude the development Bundler
group.

Since the release of 2.0.0, tests in some modules using `bundle install --without=development` are failing if gettext-setup isn't installed.