### PR TITLE
(maint) Only output gettext-setup gem errors if rake is verbose

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -23,10 +23,10 @@ begin
   if File.exist? locales_dir
     GettextSetup.initialize(locales_dir)
   else
-    puts "No 'locales' directory found in #{File.dirname(__FILE__)}, skipping gettext initialization"
+    puts "No 'locales' directory found in #{File.dirname(__FILE__)}, skipping gettext initialization" if Rake.verbose == true
   end
 rescue Gem::LoadError
-  puts "No gettext-setup gem found, skipping gettext initialization"
+  puts "No gettext-setup gem found, skipping gettext initialization" if Rake.verbose == true
 end
 
 desc "Run spec tests on an existing fixtures directory"


### PR DESCRIPTION
Previously loading the rake task would also generate text output if the
the gettext-setup was not loaded or could not be configured.  However this
breaks the compute-dev-version rake task as it should output a single line of
the module version.  This commit confines the helpful messages to only be output
if `--verbose` is specified on the Rake command line.  By default verbose is not
set.