### PR TITLE
Add dependency on parallel_tests

### DIFF
--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "mocha", "~> 1.0"
+  spec.add_runtime_dependency "parallel_tests"
   spec.add_runtime_dependency "puppet-lint", "~> 2.0"
   spec.add_runtime_dependency "puppet-syntax", "~> 2.0"
   spec.add_runtime_dependency "rspec-puppet", "~> 2.0"


### PR DESCRIPTION
The rake task release_checks uses the parallel_tests so this should be
either a dependency or the task should fall back on regular tests. Given
parallel_tests works well, I decided on the former.

Note that since parallel_tests depends on ruby >= 2.0 this also means
puppetlabs_spec_helper depends on that.