### PR TITLE
[WIP][FM-6131] Implement changelog rake task to autogen CHANGELOG.md

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -581,6 +581,39 @@ rescue LoadError
   end
 end
 
+begin
+  require 'github_changelog_generator/task'
+  require 'puppet_blacksmith/rake_tasks'
+
+  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+    metadata = (Blacksmith::Modulefile.new).metadata
+    header = <<-HERE
+# Change log
+    
+All notable changes to this project will be documented in this file. Each new release typically also includes the latest modulesync defaults, these are not documented here and do not impact functionality of this module.
+    HERE
+
+    config.add_pr_wo_labels   = false
+    config.base               = 'CHANGELOG.md'
+    config.bug_labels         = 'bugfix,maint'
+    config.bug_prefix         = 'Bug Fixes'
+    config.date_format        = '%Y-%m-%d'
+    config.enhancement_labels = 'feature'
+    config.enhancement_prefix = 'Features'
+    config.future_release     = metadata['version']
+    config.header             = header
+    config.output             = 'CHANGELOG.md'
+    config.project            = ENV['GITHUB_PROJECT'] || metadata['name']
+    config.since_tag          = ENV['LAST_TAG']
+    config.user               = ENV['GITHUB_USER'] || 'puppetlabs'
+  end
+rescue LoadError
+  desc "github_changelog_generator is not available in this installation"
+  task :changelog do
+    fail "github_changelog_generator is not available in this installation"
+  end
+end
+
 module_dir = Dir.pwd
 locales_dir = File.absolute_path('locales',  module_dir )
 # if the task is allowed to run when the module does not have a locales directory,

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "puppet-lint", "~> 2.0"
   spec.add_runtime_dependency "puppet-syntax", "~> 2.0"
   spec.add_runtime_dependency "rspec-puppet", "~> 2.0"
+  spec.add_runtime_dependency "github_changelog_generator"
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
This can be used by specifying the LAST_TAG env var when running the rake task to tell the generator which tag is the latest release tag before the current, pending release. If I was to generate a CHANGELOG.md file for version '2.0.1' I would do the following:
`CHANGELOG_GITHUB_TOKEN={YOUR PERSONAL ACCESS TOKEN} LAST_TAG=2.0.0 bundle exec rake changelog`

It is possible to specify the following env vars also:
GITHUB_PROJECT - Defaults to metadata.json `name` field
GITHUB_USER - Defaults to `puppetlabs`

The above env vars produce the github project url:
https://github.com/[GITHUB_USER]/[GITHUB_PROJECT]

The github_changelog_generator uses octokit under the hood and as such interfaces heavily with the GitHub API. Only 50 requests/hour are permitted against the github API when not using a `Personal Access Token` from GitHub. To specify this, use the `CHANGELOG_GITHUB_TOKEN` env var. One run of the changelog generator will likely exceed 50 API calls so this is a necessary step.