### PR TITLE
(maint) Properly escape paths

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -308,11 +308,11 @@ task :spec_prep do
     command = "puppet module install" + ref + flags + \
       " --ignore-dependencies" \
       " --force" \
-      " --module_working_dir #{working_dir}" \
-      " --target-dir #{target_dir} #{remote}"
+      " --module_working_dir \"#{working_dir}\"" \
+      " --target-dir \"#{target_dir}\" \"#{remote}\""
 
     unless system(command)
-      fail "Failed to install module #{remote} to #{target}"
+      fail "Failed to install module #{remote} to #{target_dir}"
     end
   end
 

--- a/lib/puppetlabs_spec_helper/version.rb
+++ b/lib/puppetlabs_spec_helper/version.rb
@@ -1,5 +1,5 @@
 module PuppetlabsSpecHelper
-  VERSION = "2.1.2"
+  VERSION = "2.1.3"
 
   # compat for pre-1.2.0 users; deprecated
   module Version


### PR DESCRIPTION
If the expanded path includes a space the puppet module tool would
interpret it as additional arguments. This change adds quotes around
the paths so that they're interpreted as single arguments.