### PR TITLE
Adding a parent rake task for i18n of a module

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -607,4 +607,11 @@ if File.exist? locales_dir
   rescue Gem::LoadError
     puts "No gettext-setup gem found, skipping gettext initialization" if Rake.verbose == true
   end
+  namespace :module do
+  desc "Runs all tasks to build a modules POT file for internationalization"
+    task :pot_gen do
+      Rake::Task["gettext:pot"].invoke()
+      Rake::Task["gettext:metadata_pot"].invoke("#{module_dir}/metadata.json")
+    end
+  end
 end


### PR DESCRIPTION
This will be the parent rake task to call all i18n rake tasks for a module to get it prepared for internationalisation. Note that it is inside the check to ensure the module has a locales directory - a sign that the module is i18n ready.