### PR TITLE
Change default logger output to STDERR.

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -193,7 +193,7 @@ def logger
      else
        level = Logger::INFO
     end
-    @logger = Logger.new(STDOUT)
+    @logger = Logger.new(STDERR)
     @logger.level = level
   end
   @logger


### PR DESCRIPTION
Logged messages are diagnostic information and it is more appropriate
for them to go to STDERR so they do not interfere with the requested
output format from RSpec. (E.g. if you request JSON format from RSpec,
only valid JSON should be output to STDOUT.)