### PR TITLE
(PDK-373) Add rake task to list spec tests

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -36,6 +36,12 @@ RSpec::Core::RakeTask.new(:spec_standalone) do |t|
   end
 end
 
+desc "List spec tests in a JSON document"
+RSpec::Core::RakeTask.new(:spec_list_json) do |t|
+  t.rspec_opts = ['--dry-run', '--format', 'json']
+  t.pattern = pattern
+end
+
 desc "Run beaker acceptance tests"
 RSpec::Core::RakeTask.new(:beaker) do |t|
   t.rspec_opts = ['--color']


### PR DESCRIPTION
Allow a module author to list their spec tests; using the same rspec pattern that :spec_standalone will use.
The task being added ( :spec_list_json ) specifies JSON so that the output can be parsed by other tools.