### PR TITLE
(PDK-409) Make directory junction targets relative to the junction

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -293,6 +293,7 @@ task :spec_prep do
     unless File.symlink?(link)
       logger.info("Creating symlink from #{link} to #{target}")
       if is_windows
+        target = File.join(File.dirname(link), target) unless Pathname.new(target).absolute?
         if Dir.respond_to?(:create_junction)
           Dir.create_junction(link, target)
         else


### PR DESCRIPTION
On POSIX hosts, symlinks are created relative to the symlink automatically (unless created with an absolute path), so if `.fixtures.yml` contains something like:

```
fixtures:
  symlinks:
    "test": "../../../test"
```

Then you end up with a link in `spec/fixtures/modules` that looks like:

```
lrwxrwxrwx  1 tsharpe tsharpe   13 Aug 10 13:29 test -> ../../../test
```

Directory junctions on windows behave differently in that they are created relative to the current working directory. In order to make the directory junctions behave in the expected way, this PR adjusts the directory junction target so that we prepend the directory where the junction is to be created (usually `spec/fixtures/modules`) to the target.

```
08/10/2017  03:38AM    <JUNCTION>      test [\??\C:\Users\Administrator\test-module\test]
```

/cc @cdenneen