### PR TITLE
(PDK-381) Ensure spec fixtures are cleaned up, even if the test fails

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -368,9 +368,12 @@ end
 
 desc "Run spec tests and clean the fixtures directory if successful"
 task :spec do
-  Rake::Task[:spec_prep].invoke
-  Rake::Task[:spec_standalone].invoke
-  Rake::Task[:spec_clean].invoke
+  begin
+    Rake::Task[:spec_prep].invoke
+    Rake::Task[:spec_standalone].invoke
+  ensure
+    Rake::Task[:spec_clean].invoke
+  end
 end
 
 desc "Parallel spec tests"
@@ -384,9 +387,10 @@ task :parallel_spec do
 
     Rake::Task[:spec_prep].invoke
     ParallelTests::CLI.new.run(args)
-    Rake::Task[:spec_clean].invoke
   rescue LoadError
     raise 'Add the parallel_tests gem to Gemfile to enable this task'
+  ensure
+    Rake::Task[:spec_clean].invoke
   end
 end
 


### PR DESCRIPTION
Currently if the rspec tests fail, the `spec_clean` task is not invoked as rake aborts. By moving the `spec_clean` task into an `ensure` block, it will get run and clean things up even when the rspec tests fail.