### PR TITLE
Fix 'abort: please specify just one revision' mercurial error

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -171,7 +171,7 @@ def revision(scm, target, ref)
   args = []
   case scm
   when 'hg'
-    args.push('update', 'clean', '-r', ref)
+    args.push('update', '--clean', '-r', ref)
   when 'git'
     args.push('reset', '--hard', ref)
   else


### PR DESCRIPTION
This commit fixes the 'abort: please specify just one revision' when using constructs like the following in .fixtures.yml:

```
my_module:
  repo: "https://hg.mycompany.com/puppet/my_module"
  scm: "hg"
  ref: "0.1.0"
```