### PR TITLE
Mercurial branch support

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -148,7 +148,7 @@ def clone_repo(scm, remote, target, subdir=nil, ref=nil, branch=nil, flags = nil
   case scm
   when 'hg'
     args.push('clone')
-    args.push('-u', ref) if ref
+    args.push('-b', branch) if branch
     args.push(flags) if flags
     args.push(remote, target)
   when 'git'
@@ -529,7 +529,7 @@ task :compute_dev_version do
   if build = ENV['BUILD_NUMBER'] || ENV['TRAVIS_BUILD_NUMBER']
     if branch.eql? "release"
       new_version = sprintf('%s-%s%04d-%s', version, "r", build, sha)
-    else 
+    else
       new_version = sprintf('%s-%04d-%s', version, build, sha)
     end
   else


### PR DESCRIPTION
Note that I also removed redundant ref update, since the repo will be updated later inside `revision()` method.

The logic is as follows:

- if `branch` key exists, the repo will be checked out and updated to the specified branch name
- if `ref` key also exists, the repo will be afterwards updated to that ref. It could be in a different branch - can't do anything about that.