### PR TITLE
(MODULES-5503) Add support for repository targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,18 @@ fixtures:
     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib"
 ```
 
+Put a supplementary repository at a different location
+
+```yaml
+fixtures:
+  repositories:
+    firewall: "git://github.com/puppetlabs/puppetlabs-firewall"
+    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib"
+    control_repo:
+      repo: "https://github.com/puppetlabs/control-repo"
+      target: "spec/fixtures/control_repos"
+```
+
 Specify that the git tag `2.4.2` of `stdlib' should be checked out:
 
 ```yaml

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -134,9 +134,18 @@ def fixtures(category)
         real_source = eval('"'+source+'"')
         result[real_source] = target
       elsif opts.instance_of?(Hash)
-        target = "spec/fixtures/modules/#{fixture}"
+
+        if opts["target"]
+          real_target = eval('"'+opts["target"]+'"')
+        end
+
+        unless real_target
+          real_target = "spec/fixtures/modules"
+        end
+
         real_source = eval('"'+opts["repo"]+'"')
-        result[real_source] = { "target" => target, "ref" => opts["ref"], "branch" => opts["branch"], "scm" => opts["scm"], "flags" => opts["flags"], "subdir" => opts["subdir"]}
+
+        result[real_source] = { "target" => File.join(real_target,fixture), "ref" => opts["ref"], "branch" => opts["branch"], "scm" => opts["scm"], "flags" => opts["flags"], "subdir" => opts["subdir"]}
       end
     end
   end


### PR DESCRIPTION
Adds the capability to add an optional 'target:' key under any
repository.

This allows a user to use the .fixtures.yml file to clone any fixtures
repository to any location to supplement the usual module testing.

MODULES-5503 #close