### PR TITLE
Fix release_checks without parallel_tests

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -389,19 +389,20 @@ end
 desc "Parallel spec tests"
 task :parallel_spec do
   begin
-    begin
-      require 'parallel_tests'
-    rescue LoadError
-      raise 'Add the parallel_tests gem to Gemfile to enable this task'
-
-    args = ['-t', 'rspec']
-    args.push('--').concat(ENV['CI_SPEC_OPTIONS'].strip.split(' ')).push('--') unless ENV['CI_SPEC_OPTIONS'].nil? || ENV['CI_SPEC_OPTIONS'].strip.empty?
-    args.concat(Rake::FileList[pattern].to_a)
-
-    Rake::Task[:spec_prep].invoke
-    ParallelTests::CLI.new.run(args)
+    require 'parallel_tests'
+  rescue LoadError
+    raise 'Add the parallel_tests gem to Gemfile to enable this task'
   ensure
-    Rake::Task[:spec_clean].invoke
+    begin
+      args = ['-t', 'rspec']
+      args.push('--').concat(ENV['CI_SPEC_OPTIONS'].strip.split(' ')).push('--') unless ENV['CI_SPEC_OPTIONS'].nil? || ENV['CI_SPEC_OPTIONS'].strip.empty?
+      args.concat(Rake::FileList[pattern].to_a)
+
+      Rake::Task[:spec_prep].invoke
+      ParallelTests::CLI.new.run(args)
+    ensure
+      Rake::Task[:spec_clean].invoke
+    end
   end
 end
 

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -12,6 +12,15 @@ rescue LoadError
   # ignore
 end
 
+parallel_tests_loaded = false
+begin
+  require 'parallel_tests'
+  parallel_tests_loaded = true
+rescue LoadError
+  # ignore
+end
+
+
 task :default => [:help]
 
 pattern = 'spec/{aliases,classes,defines,unit,functions,hosts,integration,type_aliases,types}/**/*_spec.rb'
@@ -388,21 +397,16 @@ end
 
 desc "Parallel spec tests"
 task :parallel_spec do
+  raise 'Add the parallel_tests gem to Gemfile to enable this task' unless parallel_tests_loaded
   begin
-    require 'parallel_tests'
-  rescue LoadError
-    raise 'Add the parallel_tests gem to Gemfile to enable this task'
-  ensure
-    begin
-      args = ['-t', 'rspec']
-      args.push('--').concat(ENV['CI_SPEC_OPTIONS'].strip.split(' ')).push('--') unless ENV['CI_SPEC_OPTIONS'].nil? || ENV['CI_SPEC_OPTIONS'].strip.empty?
-      args.concat(Rake::FileList[pattern].to_a)
+    args = ['-t', 'rspec']
+    args.push('--').concat(ENV['CI_SPEC_OPTIONS'].strip.split(' ')).push('--') unless ENV['CI_SPEC_OPTIONS'].nil? || ENV['CI_SPEC_OPTIONS'].strip.empty?
+    args.concat(Rake::FileList[pattern].to_a)
 
-      Rake::Task[:spec_prep].invoke
-      ParallelTests::CLI.new.run(args)
-    ensure
-      Rake::Task[:spec_clean].invoke
-    end
+    Rake::Task[:spec_prep].invoke
+    ParallelTests::CLI.new.run(args)
+  ensure
+    Rake::Task[:spec_clean].invoke
   end
 end
 
@@ -554,9 +558,9 @@ desc "Runs all necessary checks on a module in preparation for a release"
 task :release_checks do
   Rake::Task[:lint].invoke
   Rake::Task[:validate].invoke
-  begin
+  if parallel_tests_loaded
     Rake::Task[:parallel_spec].invoke
-  rescue RuntimeError
+  else
     Rake::Task[:spec].invoke
   end
   Rake::Task["check:symlinks"].invoke

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -389,7 +389,10 @@ end
 desc "Parallel spec tests"
 task :parallel_spec do
   begin
-    require 'parallel_tests'
+    begin
+      require 'parallel_tests'
+    rescue LoadError
+      raise 'Add the parallel_tests gem to Gemfile to enable this task'
 
     args = ['-t', 'rspec']
     args.push('--').concat(ENV['CI_SPEC_OPTIONS'].strip.split(' ')).push('--') unless ENV['CI_SPEC_OPTIONS'].nil? || ENV['CI_SPEC_OPTIONS'].strip.empty?
@@ -397,8 +400,6 @@ task :parallel_spec do
 
     Rake::Task[:spec_prep].invoke
     ParallelTests::CLI.new.run(args)
-  rescue LoadError
-    raise 'Add the parallel_tests gem to Gemfile to enable this task'
   ensure
     Rake::Task[:spec_clean].invoke
   end


### PR DESCRIPTION
:release_checks attempts :parallel_spec then :spec if it fails, with https://github.com/puppetlabs/puppetlabs_spec_helper/commit/920d64798ac915c2ffea7434d04e0717ee3251f1 which causes :spec_clean to be invoked twice if parallel_tests is not installed, but crucially it doesn't execute it twice and therefore causes check:symlinks to fail every time when ran via :release_checks without parallel_tests gem