### PR TITLE
(WIN-6) Add test_tiers env var parsing to support test tiering.

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,16 @@ remembering to duplicate any existing environment variables:
     env:
       - FUTURE_PARSER=yes CI_NODE_TOTAL=2 CI_NODE_INDEX=1
       - FUTURE_PARSER=yes CI_NODE_TOTAL=2 CI_NODE_INDEX=2
+      
+#### Running tests tagged with test tiers
+To run tests tagged with risk levels set the ``TEST_TIERS`` environment variable to a comma-separated list of 
+the appropriate tiers.
+
+For example: to run tests marked ``tier_high => true`` and ``tier_medium => true`` in the same test run set the 
+environment variable``TEST_TIERS=high,medium``
+  
+Note, if the ``TEST_TIERS`` environment variable is set to empty string or nil, all tiers will be executed.
+
 
 Generating code coverage reports
 ================================

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -55,6 +55,20 @@ desc "Run beaker acceptance tests"
 RSpec::Core::RakeTask.new(:beaker) do |t|
   t.rspec_opts = ['--color']
   t.pattern = 'spec/acceptance'
+  # TEST_TIERS env variable is a comma separated list of tiers to run. e.g. low, medium, high
+  if ENV['TEST_TIERS']
+    tiers = '--tag '
+    test_tiers = ENV['TEST_TIERS'].split(',')
+    raise 'TEST_TIERS env variable must have at least 1 tier specified. low, medium or high (comma separated).' if test_tiers.count == 0
+    test_tiers.each do |tier|
+      raise "#{tier} not a valid test tier." unless %w(low medium high).include?(tier)
+      tiers += "tier_#{tier},"
+    end
+    tiers = tiers.chomp(',')
+    t.rspec_opts.push(tiers)
+  else
+    puts 'TEST_TIERS env variable not defined. Defaulting to run all tests.'
+  end
 end
 
 # This is a helper for the self-symlink entry of fixtures.yml


### PR DESCRIPTION
Need this to properly parse the test_tiers environment variable now being set in sqlserver pipelines as per https://tickets.puppetlabs.com/browse/WIN-6