### PR TITLE
(MAINT) fix condition where there are no fixtures

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -149,7 +149,7 @@ def fixtures(category)
     fixture_defaults = {}
   end
 
-  fixtures = fixtures['fixtures']
+  fixtures = fixtures['fixtures'] || {}
 
   if fixtures['symlinks'].nil?
     fixtures['symlinks'] = auto_symlink


### PR DESCRIPTION
I believe this is causing our tests to fail.  

From Travis CI for Bolt
The command "cd modules/boltlib" exited with 0.
1.05s$ bundle exec rake spec
rake aborted!
NoMethodError: undefined method `[]' for nil:NilClass
/home/travis/build/puppetlabs/bolt/vendor/bundle/ruby/2.4.0/gems/puppetlabs_spec_helper-2.6.0/lib/puppetlabs_spec_helper/rake_tasks.rb:154:in `fixtures'
/home/travis/build/puppetlabs/bolt/vendor/bundle/ruby/2.4.0/gems/puppetlabs_spec_helper-2.6.0/lib/puppetlabs_spec_helper/rake_tasks.rb:386:in `block in <top (required)>'
/home/travis/build/puppetlabs/bolt/vendor/bundle/ruby/2.4.0/gems/puppetlabs_spec_helper-2.6.0/lib/puppetlabs_spec_helper/rake_tasks.rb:415:in `ensure in block in <top (required)>'
/home/travis/build/puppetlabs/bolt/vendor/bundle/ruby/2.4.0/gems/puppetlabs_spec_helper-2.6.0/lib/puppetlabs_spec_helper/rake_tasks.rb:415:in `block in <top (required)>'
/home/travis/.rvm/gems/ruby-2.4.1/bin/bundle:23:in `load'
/home/travis/.rvm/gems/ruby-2.4.1/bin/bundle:23:in `<main>'
NoMethodError: undefined method `[]' for nil:NilClass
/home/travis/build/puppetlabs/bolt/vendor/bundle/ruby/2.4.0/gems/puppetlabs_spec_helper-2.6.0/lib/puppetlabs_spec_helper/rake_tasks.rb:154:in `fixtures'
/home/travis/build/puppetlabs/bolt/vendor/bundle/ruby/2.4.0/gems/puppetlabs_spec_helper-2.6.0/lib/puppetlabs_spec_helper/rake_tasks.rb:86:in `repositories'
/home/travis/build/puppetlabs/bolt/vendor/bundle/ruby/2.4.0/gems/puppetlabs_spec_helper-2.6.0/lib/puppetlabs_spec_helper/rake_tasks.rb:306:in `block in <top (required)>'
/home/travis/build/puppetlabs/bolt/vendor/bundle/ruby/2.4.0/gems/puppetlabs_spec_helper-2.6.0/lib/puppetlabs_spec_helper/rake_tasks.rb:412:in `block in <top (required)>'
/home/travis/.rvm/gems/ruby-2.4.1/bin/bundle:23:in `load'
/home/travis/.rvm/gems/ruby-2.4.1/bin/bundle:23:in `<main>'
Tasks: TOP => spec_clean
(See full trace by running task with --trace)