### PR TITLE
Fix fixtures handling for missing file or missing `fixtures:` section

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -149,7 +149,7 @@ def fixtures(category)
     fixture_defaults = {}
   end
 
-  fixtures = fixtures['fixtures']
+  fixtures = fixtures['fixtures'] || {}
 
   if fixtures['symlinks'].nil?
     fixtures['symlinks'] = auto_symlink


### PR DESCRIPTION
After submitting PR #218 to add the defaults: section to the .fixtures.yml file, handling of missing .fixtures.yml files or missing fixtures: sections broke.

This PR fixes that in the simplest way - by ensuring that `fixtures` is always a hash.