### PR TITLE
(MODULES-6606) change to initialize_config

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -693,15 +693,15 @@ if File.exist? locales_dir
     spec = Gem::Specification.find_by_name 'gettext-setup'
     load "#{spec.gem_dir}/lib/tasks/gettext.rake"
     # Initialization requires a valid locales directory
-    GettextSetup.initialize(locales_dir)
-  rescue Gem::LoadError
-    puts "No gettext-setup gem found, skipping gettext initialization" if Rake.verbose == true
-  end
-  namespace :module do
-  desc "Runs all tasks to build a modules POT file for internationalization"
-    task :pot_gen do
-      Rake::Task["gettext:pot"].invoke()
-      Rake::Task["gettext:metadata_pot"].invoke("#{module_dir}/metadata.json")
+    GettextSetup.initialize_config(locales_dir)
+    namespace :module do
+      desc "Runs all tasks to build a modules POT file for internationalization"
+      task :pot_gen do
+        Rake::Task["gettext:pot"].invoke()
+        Rake::Task["gettext:metadata_pot"].invoke("#{module_dir}/metadata.json")
+      end
     end
+  rescue Gem::LoadError
+    puts "No gettext-setup gem found, skipping GettextSetup config initialization" if Rake.verbose == true
   end
 end

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "yard"
-  spec.add_development_dependency "gettext-setup", "~> 0.13"
+  spec.add_development_dependency "gettext-setup", "~> 0.29"
 end


### PR DESCRIPTION
This is related to the issue where Puppet and GettextSetup are butting heads with FastGettext. We want to stop using GettextSetup.initialize because it is causing problems while running tests for modules but also because we do not need to anymore, there is now a method available called initialize_config we can use since we are only loading rake tasks with PSH