### PR TITLE
(DO NOT MERGE) Removes the unit test run from the release_checks task

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -613,11 +613,6 @@ desc "Runs all necessary checks on a module in preparation for a release"
 task :release_checks do
   Rake::Task[:lint].invoke
   Rake::Task[:validate].invoke
-  if parallel_tests_loaded
-    Rake::Task[:parallel_spec].invoke
-  else
-    Rake::Task[:spec].invoke
-  end
   Rake::Task["check:symlinks"].invoke
   Rake::Task["check:test_file"].invoke
   Rake::Task["check:dot_underscore"].invoke


### PR DESCRIPTION
Due to the way we are currently using release checks we have decided to remove the spec test run and keep the checks separate.