### PR TITLE
(FM-6795) prefer ruby > 2.1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: ruby
 cache: bundler
+bundler_args: --without development
 before_install:
   # https://github.com/bundler/bundler/issues/3558
   gem update bundler

--- a/Gemfile
+++ b/Gemfile
@@ -4,14 +4,11 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem "puppet", ENV['PUPPET_GEM_VERSION'] || ENV['PUPPET_VERSION'] || '~> 4.0'
+  gem "puppet", ENV['PUPPET_GEM_VERSION'] || ENV['PUPPET_VERSION'] || '~> 5.0'
   gem 'rubocop'
   gem 'rubocop-rspec', '~> 1.6' if RUBY_VERSION >= '2.3.0'
 end
 
-# json_pure 2.0.2 added a requirement on ruby >= 2. We pin to json_pure 2.0.1
-# if using ruby 1.x
-gem 'json_pure', '<=2.0.1'
 gem 'rack', '~> 1'
 
 # vim:filetype=ruby

--- a/Gemfile
+++ b/Gemfile
@@ -1,22 +1,17 @@
 source 'https://rubygems.org'
 
 # Specify the global dependencies in puppetlabs_spec_helper.gemspec
-# Note that only ruby 1.9 compatible dependencies may go there, everything else needs to be documented and pulled in manually, and optionally by everyone who wants to use the extended features.
 gemspec
 
 group :development do
   gem "puppet", ENV['PUPPET_GEM_VERSION'] || ENV['PUPPET_VERSION'] || '~> 4.0'
-  if RUBY_VERSION =~ /^1\./
-    gem 'rubocop', '0.41.2'
-  else
-    gem 'rubocop'
-    gem 'rubocop-rspec', '~> 1.6' if RUBY_VERSION >= '2.3.0'
-  end
+  gem 'rubocop'
+  gem 'rubocop-rspec', '~> 1.6' if RUBY_VERSION >= '2.3.0'
 end
 
 # json_pure 2.0.2 added a requirement on ruby >= 2. We pin to json_pure 2.0.1
 # if using ruby 1.x
-gem 'json_pure', '<=2.0.1', :require => false if RUBY_VERSION =~ /^1\./
+gem 'json_pure', '<=2.0.1'
 gem 'rack', '~> 1'
 
 # vim:filetype=ruby

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ gemspec
 
 group :development do
   gem "puppet", ENV['PUPPET_GEM_VERSION'] || ENV['PUPPET_VERSION'] || '~> 5.0'
-  gem 'rubocop'
-  gem 'rubocop-rspec', '~> 1.6' if RUBY_VERSION >= '2.3.0'
+  gem 'rubocop', '= 0.49.1'
+  gem 'rubocop-rspec', '= 1.15.1'
 end
 
 gem 'rack', '~> 1'

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,9 @@ group :development do
   gem 'rubocop-rspec', '= 1.15.1'
 end
 
+# json_pure 2.0.2 added a requirement on ruby >= 2. We pin to json_pure 2.0.1
+# if using ruby 1.x
+gem 'json_pure', '<=2.0.1', :require => false if RUBY_VERSION =~ /^1\./
 gem 'rack', '~> 1'
 
 # vim:filetype=ruby

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "puppet"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "yard"
   spec.add_development_dependency "gettext-setup", "~> 0.29"


### PR DESCRIPTION
This removes some logic and updates some dependencies to drop support for ruby versions less than 2.1.9. This was mainly driven by a sec vulnerability found in an old version of rubocop. In order to bump rubocop, we had to get rid of ruby 1.9.3