### PR TITLE
Add all spec/lib directories from fixtures to LOAD_PATH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,28 +3,28 @@ dist: xenial
 language: ruby
 cache: bundler
 before_install: bundle -v
-script: env COVERAGE=yes bundle exec rake
-jobs:
+script: bundle exec rake
+matrix:
   fast_finish: true
   include:
   - rvm: '2.7'
     env: PUPPET_GEM_VERSION='https://github.com/puppetlabs/puppet.git#master' # TODO: change to 7 once it becomes available
   - rvm: '2.6'
-    env: PUPPET_GEM_VERSION='~> 6.0'
+    env: PUPPET_GEM_VERSION='~> 6.0' COVERAGE=yes
   - rvm: '2.5'
-    env: PUPPET_GEM_VERSION='~> 6.0'
+    env: PUPPET_GEM_VERSION='~> 6.0' COVERAGE=yes
   - rvm: '2.4'
-    env: PUPPET_GEM_VERSION='~> 6.0'
+    env: PUPPET_GEM_VERSION='~> 6.0' COVERAGE=yes
   - rvm: '2.3'
     env: PUPPET_GEM_VERSION='~> 6.0'
   - rvm: '2.4'
-    env: PUPPET_GEM_VERSION='~> 5.0'
+    env: PUPPET_GEM_VERSION='~> 5.0' COVERAGE=yes
   - rvm: '2.3'
     env: PUPPET_GEM_VERSION='~> 5.0'
   - rvm: '2.1'
     env: PUPPET_GEM_VERSION='~> 5.0'
   - rvm: '2.4'
-    env: PUPPET_GEM_VERSION='~> 4.0'
+    env: PUPPET_GEM_VERSION='~> 4.0' COVERAGE=yes
   - rvm: '2.3'
     env: PUPPET_GEM_VERSION='~> 4.0'
   - rvm: '2.1'

--- a/README.md
+++ b/README.md
@@ -335,6 +335,10 @@ fixtures:
         ref: "2.6.0"
 ```
 
+Fixture Loading
+---------------
+Any module that has a `spec/lib` directory will be available on the ruby `LOAD_PATH` for tests to consume. This allows modules to provide additional helper code to be supplied. The [augeasprovider_core](https://github.com/hercules-team/augeasproviders_core) module has [some examples](https://github.com/hercules-team/augeasproviders_core/tree/master/spec/lib).
+
 Testing Parser Functions
 ========================
 

--- a/lib/puppetlabs_spec_helper/module_spec_helper.rb
+++ b/lib/puppetlabs_spec_helper/module_spec_helper.rb
@@ -50,6 +50,14 @@ if ENV['SIMPLECOV'] == 'yes'
   end
 end
 
+# Add all spec lib dirs to LOAD_PATH
+components = module_path.split(File::PATH_SEPARATOR).collect do |dir|
+  Dir.entries(dir).reject { |f| f =~ %r{^\.} }.collect { |f| File.join(dir, f, 'spec', 'lib') }
+end
+components.flatten.each do |d|
+  $LOAD_PATH << d if FileTest.directory?(d) && !$LOAD_PATH.include?(d)
+end
+
 RSpec.configure do |c|
   c.environmentpath = spec_path if Puppet.version.to_f >= 4.0
   c.module_path = module_path


### PR DESCRIPTION
Allow puppet modules to provide helper spec libraries. For an example see https://github.com/hercules-team/augeasproviders_core/tree/master/spec/lib