### PR TITLE
(maint) change testsuite not to use mocha

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,11 @@
+require 'puppetlabs_spec_helper/puppet_spec_helper'
+require 'puppetlabs_spec_helper/puppetlabs_spec/puppet_internals'
+require 'puppetlabs_spec_helper/rake_tasks'
+
+# configure RSpec after including all the code
+RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+  config.mock_with :rspec
+end

--- a/spec/unit/puppetlabs_spec_helper/puppetlabs_spec/puppet_internals_spec.rb
+++ b/spec/unit/puppetlabs_spec_helper/puppetlabs_spec/puppet_internals_spec.rb
@@ -1,11 +1,4 @@
 require 'spec_helper'
-require 'puppetlabs_spec_helper/puppet_spec_helper'
-require 'puppetlabs_spec_helper/puppetlabs_spec/puppet_internals'
-
-# reset mock integration
-RSpec.configure do |c|
-  c.mock_with :rspec
-end
 
 describe PuppetlabsSpec::PuppetInternals do
   before(:all) do
@@ -88,12 +81,12 @@ describe PuppetlabsSpec::PuppetInternals do
     it 'accepts an injected scope' do
       expect(Puppet::Parser::Functions).to receive(:function).with('my_func').and_return(true)
       scope = double(described_class.scope)
-      scope.expects(:method).with(:function_my_func).returns(:fake_method)
+      expect(scope).to receive(:method).with(:function_my_func).and_return(:fake_method)
       expect(described_class.function_method('my_func', scope: scope)).to eq(:fake_method)
     end
 
     it "returns nil if the function doesn't exist" do
-      Puppet::Parser::Functions.expects(:function).with('my_func').returns(false)
+      expect(Puppet::Parser::Functions).to receive(:function).with('my_func').and_return(false)
       scope = double(described_class.scope)
       expect(described_class.function_method('my_func', scope: scope)).to be_nil
     end

--- a/spec/unit/puppetlabs_spec_helper/rake_task_spec.rb
+++ b/spec/unit/puppetlabs_spec_helper/rake_task_spec.rb
@@ -1,10 +1,4 @@
-require 'puppetlabs_spec_helper/puppet_spec_helper'
-require 'puppetlabs_spec_helper/rake_tasks'
-
-RSpec.configure do |config|
-  config.mock_with :rspec
-  config.include PuppetlabsSpecHelper::RakeTasks
-end
+require 'spec_helper'
 
 describe SetupBeaker do
   describe '.setup_beaker' do


### PR DESCRIPTION
With the release of mocha 1.5.0 these two tests started failing. This
removes mocha from the test suite.