### PR TITLE
(PDK-636) Always remove symlink fixtures. Only remove downloaded fixtures if tests pass.

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -60,8 +60,9 @@ task :spec do |t, args|
   begin
     Rake::Task[:spec_prep].invoke
     Rake::Task[:spec_standalone].invoke(*args.extras)
-  ensure
     Rake::Task[:spec_clean].invoke
+  ensure
+    Rake::Task[:spec_clean_symlinks].invoke
   end
 end
 
@@ -78,8 +79,9 @@ task :parallel_spec do
 
       Rake::Task[:spec_prep].invoke
       ParallelTests::CLI.new.run(args)
-    ensure
       Rake::Task[:spec_clean].invoke
+    ensure
+      Rake::Task[:spec_clean_symlinks].invoke
     end
   end
 end

--- a/lib/puppetlabs_spec_helper/tasks/fixtures.rb
+++ b/lib/puppetlabs_spec_helper/tasks/fixtures.rb
@@ -317,12 +317,17 @@ task :spec_clean do
 
   FileUtils::rm_rf(module_working_directory)
 
-  fixtures("symlinks").each do |source, opts|
-    target = opts["target"]
-    FileUtils::rm_f(target)
-  end
+  Rake::Task[:spec_clean_symlinks].invoke
 
   if File.zero?("spec/fixtures/manifests/site.pp")
     FileUtils::rm_f("spec/fixtures/manifests/site.pp")
+  end
+end
+
+desc "Clean up any fixture symlinks"
+task :spec_clean_symlinks do
+  fixtures("symlinks").each do |source, opts|
+    target = opts["target"]
+    FileUtils::rm_f(target)
   end
 end


### PR DESCRIPTION
Restores most of the original behaviour of running `spec`, so that downloaded fixtures are only cleaned up if the tests pass. Fixtures created from symlinks (which cause problems when kept around) are still always removed at the end of each test run regardless of pass or fail.