### PR TITLE
(PDK-636) Groundwork to allow PDK to persist downloaded fixtures

### DIFF
--- a/lib/puppetlabs_spec_helper/tasks/fixtures.rb
+++ b/lib/puppetlabs_spec_helper/tasks/fixtures.rb
@@ -301,7 +301,8 @@ task :spec_prep do
       ref = " --version #{opts['ref']}" if not opts['ref'].nil?
       flags = " #{opts['flags']}" if opts['flags']
     end
-    next if File::exists?(target)
+
+    next if File.directory?(target)
 
     working_dir = module_working_directory
     target_dir = File.expand_path('spec/fixtures/modules')


### PR DESCRIPTION
 * Adds a `parallel_spec_standalone` rake task (ala `spec_standalone`) to allow for running parallel_spec without triggering fixtures
 * Updates the fixtures-from-scm logic to run `git fetch`/`hg pull` if the repo has already been cloned in a previous run