### PR TITLE
(PDK-1033) Use `--unshallow` when fetching a ref

### DIFF
--- a/lib/puppetlabs_spec_helper/tasks/fixtures.rb
+++ b/lib/puppetlabs_spec_helper/tasks/fixtures.rb
@@ -124,17 +124,23 @@ module PuppetlabsSpecHelper::Tasks::FixtureHelpers
   end
 
   def update_repo(scm, target)
-    args = case scm
-           when 'hg'
-             ['pull']
-           when 'git'
-             ['fetch']
-           else
-             raise "Unfortunately #{scm} is not supported yet"
-           end
     Dir.chdir(target) do
+      args = case scm
+             when 'hg'
+               ['pull']
+             when 'git'
+               ['fetch'].tap do |git_args|
+                 git_args << '--unshallow' if shallow_git_repo?
+               end
+             else
+               raise "Unfortunately #{scm} is not supported yet"
+             end
       system("#{scm} #{args.flatten.join(' ')}")
     end
+  end
+
+  def shallow_git_repo?
+    File.file?(File.join('.git', 'shallow'))
   end
 
   def revision(scm, target, ref)


### PR DESCRIPTION
git does not fetch beyond the original depth in shallow repositories. This change uses `--unshallow` when a `ref` is specified, to avoid the issues shown in PDK-1033, namely not being able to switch from a shallow non-`ref` fixture clone to one with a `ref` to outside the original clone.