### PR TITLE
(PDK-1031) Remove thread-unsafe Dir.chdir usage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,11 +6,11 @@ gemspec
 
 group :development do
   gem 'codecov'
-  gem 'github_changelog_generator'
+  gem 'github_changelog_generator' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.0')
   gem 'puppet', ENV['PUPPET_GEM_VERSION'] || ENV['PUPPET_VERSION'] || '~> 4.0'
   gem 'simplecov', '~> 0'
   gem 'simplecov-console'
-  if RUBY_VERSION >= '2.1'
+  if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
     gem 'rubocop', '< 0.50'
     gem 'rubocop-rspec', '~> 1'
   end

--- a/lib/puppetlabs_spec_helper/tasks/fixtures.rb
+++ b/lib/puppetlabs_spec_helper/tasks/fixtures.rb
@@ -125,19 +125,17 @@ module PuppetlabsSpecHelper::Tasks::FixtureHelpers
   end
 
   def update_repo(scm, target)
-    Dir.chdir(target) do
-      args = case scm
-             when 'hg'
-               ['pull']
-             when 'git'
-               ['fetch'].tap do |git_args|
-                 git_args << '--unshallow' if shallow_git_repo?
-               end
-             else
-               raise "Unfortunately #{scm} is not supported yet"
+    args = case scm
+           when 'hg'
+             ['pull']
+           when 'git'
+             ['fetch'].tap do |git_args|
+               git_args << '--unshallow' if shallow_git_repo?
              end
-      system("#{scm} #{args.flatten.join(' ')}")
-    end
+           else
+             raise "Unfortunately #{scm} is not supported yet"
+           end
+    system("#{scm} #{args.flatten.join(' ')}", chdir: target)
   end
 
   def shallow_git_repo?
@@ -154,7 +152,7 @@ module PuppetlabsSpecHelper::Tasks::FixtureHelpers
     else
       raise "Unfortunately #{scm} is not supported yet"
     end
-    system("cd #{target} && #{scm} #{args.flatten.join ' '}")
+    system("#{scm} #{args.flatten.join ' '}", chdir: target)
   end
 
   def valid_repo?(scm, target, remote)


### PR DESCRIPTION
MRI's `Dir.chdir` is not thread safe, so we can't use that. Instead, this PR changes it so that we pass the desired working directory to `Kernel.system` which changes the working directory of the child process without changing the parent's working directory.