### PR TITLE
(maint) - Release prep for 2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All significant changes to this repo will be summarized in this file.
 
 
+## [v2.9.1](https://github.com/puppetlabs/puppetlabs_spec_helper/tree/v2.9.1) (2018-06-20)
+[Full Changelog](https://github.com/puppetlabs/puppetlabs_spec_helper/compare/v2.9.0...v2.9.1)
+
+**Fixed bugs:**
+
+- \(PDK-1031\) Remove thread-unsafe Dir.chdir usage [\#249](https://github.com/puppetlabs/puppetlabs_spec_helper/pull/249) ([rodjek](https://github.com/rodjek))
+- \(PDK-1033\) Use `--unshallow` when fetching a ref [\#247](https://github.com/puppetlabs/puppetlabs_spec_helper/pull/247) ([DavidS](https://github.com/DavidS))
+
 ## [v2.9.0](https://github.com/puppetlabs/puppetlabs_spec_helper/tree/v2.9.0) (2018-06-18)
 [Full Changelog](https://github.com/puppetlabs/puppetlabs_spec_helper/compare/v2.8.0...v2.9.0)
 
@@ -12,6 +20,7 @@ All significant changes to this repo will be summarized in this file.
 
 **Merged pull requests:**
 
+- Release prep 2.9.0 [\#248](https://github.com/puppetlabs/puppetlabs_spec_helper/pull/248) ([DavidS](https://github.com/DavidS))
 - Stable development structure for this gem [\#246](https://github.com/puppetlabs/puppetlabs_spec_helper/pull/246) ([cardil](https://github.com/cardil))
 
 # Previous Changes

--- a/lib/puppetlabs_spec_helper/version.rb
+++ b/lib/puppetlabs_spec_helper/version.rb
@@ -1,5 +1,5 @@
 module PuppetlabsSpecHelper
-  VERSION = '2.9.0'.freeze
+  VERSION = '2.9.1'.freeze
 
   # compat for pre-1.2.0 users; deprecated
   module Version


### PR DESCRIPTION
I have generated the README using the built in changelog generation rake task. 
Prepping for a release following 2.9.0.

All unit tests have passed: 
`
Finished in 0.34544 seconds (files took 1.09 seconds to load)
26 examples, 0 failures
`

All acceptance tests have passed:
`
Finished in 1.15 seconds (files took 1.06 seconds to load)
3 examples, 0 failures
`

