### PR TITLE
add support to override the allowed test tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,10 +346,15 @@ remembering to duplicate any existing environment variables:
       - FUTURE_PARSER=yes CI_NODE_TOTAL=2 CI_NODE_INDEX=2
 
 #### Running tests tagged with test tiers
-To run tests tagged with risk levels set the ``TEST_TIERS`` environment variable to a comma-separated list of the appropriate tiers.  Supported tiers are high, medium and low.
+To run tests tagged with risk levels set the ``TEST_TIERS`` environment variable to a comma-separated list of the appropriate tiers.
 
 For example: to run tests marked ``tier_high => true`` and ``tier_medium => true`` in the same test run set the
 environment variable``TEST_TIERS=high,medium``
+
+By default ``TEST_TIERS`` only accepts low, medium and high as valid tiers.  If you would like to use your own keywords to set the environment variable ``TEST_TIERS_ALLOWED``.
+
+For example: to use the keywords dev, rnd, staging and production you can set 
+``TEST_TIERS_ALLOWED=dev,rnd,staging,production``. Then you would be able to run tests marked ``tier_dev => true``, ``tier_production => true`` with ``TEST_TIERS=dev,production``
 
 Note, if the ``TEST_TIERS`` environment variable is set to empty string or nil, all tiers will be executed.
 

--- a/lib/puppetlabs_spec_helper/tasks/beaker.rb
+++ b/lib/puppetlabs_spec_helper/tasks/beaker.rb
@@ -64,10 +64,11 @@ class SetupBeaker
     # TEST_TIERS env variable is a comma separated list of tiers to run. e.g. low, medium, high
     if ENV['TEST_TIERS']
       test_tiers = ENV['TEST_TIERS'].split(',')
-      raise 'TEST_TIERS env variable must have at least 1 tier specified. low, medium or high (comma separated).' if test_tiers.count == 0
+      test_tiers_allowed = ENV.fetch('TEST_TIERS_ALLOWED', 'low,medium,high').split(',')
+      raise 'TEST_TIERS env variable must have at least 1 tier specified. Either low, medium or high or one of the tiers listed in TEST_TIERS_ALLOWED (comma separated).' if test_tiers.count == 0
       test_tiers.each do |tier|
         tier_to_add = tier.strip.downcase
-        raise "#{tier_to_add} not a valid test tier." unless %w[low medium high].include?(tier_to_add)
+        raise "#{tier_to_add} not a valid test tier." unless test_tiers_allowed.include?(tier_to_add)
         tiers = "--tag tier_#{tier_to_add}"
         t.rspec_opts.push(tiers)
       end

--- a/spec/unit/puppetlabs_spec_helper/tasks/beaker_spec.rb
+++ b/spec/unit/puppetlabs_spec_helper/tasks/beaker_spec.rb
@@ -25,5 +25,19 @@ describe SetupBeaker do
       allow(ENV).to receive(:[]).and_return('"high", "medium", "low"')
       expect { described_class.setup_beaker(task) }.to raise_error(RuntimeError, %r{not a valid test tier})
     end
+    it 'errors when tiers are not in the allowe list' do
+      allow(ENV).to receive(:[]).and_return('foobar')
+      expect { described_class.setup_beaker(task) }.to raise_error(RuntimeError, %r{not a valid test tier})
+    end
+    it 'Override TEST_TIERS_ALLOWED' do
+      allow(ENV).to receive(:fetch).with('TEST_TIERS_ALLOWED', 'low,medium,high').and_return('dev,rnd')
+      allow(ENV).to receive(:[]).with('TEST_TIERS').and_return('dev')
+      expect(described_class.setup_beaker(task).rspec_opts.to_s).to match(%r{--tag tier_dev})
+    end
+    it 'Override TEST_TIERS_ALLOWED and error if tier not avalible' do
+      allow(ENV).to receive(:fetch).with('TEST_TIERS_ALLOWED', 'low,medium,high').and_return('dev,rnd')
+      allow(ENV).to receive(:[]).with('TEST_TIERS').and_return('foobar')
+      expect { described_class.setup_beaker(task) }.to raise_error(RuntimeError, %r{not a valid test tier})
+    end
   end
 end


### PR DESCRIPTION
This PR adds support for a new environment variable `TEST_TIERS_ALLOWED` to allow users to override the default list of allowed test teirs