### PR TITLE
Fix example conversion from mocha to rspec mocks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ context.stubs(:some_method).with(arguments).returns('value')
 ```
 to this:
 ```
-allow(context).to receive(:some_method).with(arguments).and_returns('value')
+allow(context).to receive(:some_method).with(arguments).and_return('value')
 ```
 
 Translate all expectations:
@@ -470,7 +470,7 @@ context.expects(:some_method).with(arguments).returns('value')
 ```
 to this:
 ```
-expect(context).to receive(:some_method).with(arguments).and_returns('value')
+expect(context).to receive(:some_method).with(arguments).and_return('value')
 ```
 
 Rationale


### PR DESCRIPTION
rspec mocks uses `and_return`, not `and_returns`