### PR TITLE
(MODULES-7856) Allow optional repositories based on puppet version

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ When specifying the repo source of the fixture you have a few options as to whic
    ```yaml
    flags: --verbose
    ```
- * puppet_version - versions of puppet for which the fixture should be installed. Ruby version constraints are supported. Only supported on puppet 4.0 and up.
+ * puppet_version - versions of puppet for which the fixture should be installed. Ruby version constraints are supported. Only works when the `semantic_puppet` gem is available (shipped with puppet 4.0 and up, by default).
 
    ```yaml
    puppet_version: '>= 6.0.0'

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ file named `.fixtures.yml` in the root of the project. You can specify a alterna
 You can use the `MODULE_WORKING_DIR` environment variable to specify a diffent location when installing module fixtures via the forge. By default the
 working directory is `<module directory>/spec/fixtures/work-dir`.
 
-When specifying the repo source of the fixture you have a few options as to which revision of the codebase you wish to use.
+When specifying the repo source of the fixture you have a few options as to which revision of the codebase you wish to use, and optionally, the puppet versions where the fixture is needed.
 
  * repo - the url to the repo
  * scm - options include git or hg. This is an optional step as the helper code will figure out which scm is used.
@@ -214,6 +214,11 @@ When specifying the repo source of the fixture you have a few options as to whic
 
    ```yaml
    flags: --verbose
+   ```
+ * puppet_version - versions of puppet for which the fixture should be installed. Ruby version constraints are supported. Only supported on puppet 4.0 and up.
+
+   ```yaml
+   puppet_version: '>= 6.0.0'
    ```
 
  **Note:** ref and branch can be used together to get a specific revision on a specific branch
@@ -261,6 +266,16 @@ fixtures:
     stdlib:
       repo: "git://github.com/puppetlabs/puppetlabs-stdlib"
       ref: "2.6.0"
+```
+
+Only install the `yumrepo_core` module when testing against Puppet 6 or greater:
+
+```yaml
+fixtures:
+  repositories:
+    yumrepo_core:
+      repo: "git://github.com/puppetlabs/puppetlabs-yumrepo_core"
+      puppet_version: ">= 6.0.0"
 ```
 
 Move manifests and siblings to root directory when they are inside a `code` directory:

--- a/lib/puppetlabs_spec_helper/tasks/fixtures.rb
+++ b/lib/puppetlabs_spec_helper/tasks/fixtures.rb
@@ -84,6 +84,8 @@ module PuppetlabsSpecHelper::Tasks::FixtureHelpers
         # final option list
         opts = defaults.merge(opts)
 
+        next unless include_repo?(opts['puppet_version'])
+
         real_target = eval('"' + opts['target'] + '"')
         real_source = eval('"' + opts['repo'] + '"')
 
@@ -98,6 +100,18 @@ module PuppetlabsSpecHelper::Tasks::FixtureHelpers
       end
     end
     result
+  end
+
+  def include_repo?(version_range)
+    if version_range && defined?(SemanticPuppet)
+      puppet_spec = Gem::Specification.find_by_name('puppet')
+      puppet_version = SemanticPuppet::Version.parse(puppet_spec.version.to_s)
+
+      constraint = SemanticPuppet::VersionRange.parse(version_range)
+      constraint.include?(puppet_version)
+    else
+      true
+    end
   end
 
   def clone_repo(scm, remote, target, _subdir = nil, ref = nil, branch = nil, flags = nil)


### PR DESCRIPTION
Some types/providers maybe missing when testing against puppet6 as a
gem. Allow an optional repository to be specified which will only be
installed if the current puppet version matches the semantic version
constraint. For example, stdlib will always be installed, but
selinux_core is only installed when testing on puppet6 or above:

    repositories:
      stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
      selinux_core:
        repo: https://github.com/puppetlabs/puppetlabs-selinux_core.git
        puppet_version: ">= 6.0.0"