### PR TITLE
(PDK-1100) Use PDK to build module packages

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -103,14 +103,10 @@ end
 
 desc 'Build puppet module package'
 task :build do
-  begin
-    require 'pdk/module/build'
+  require 'pdk/module/build'
 
-    path = PDK::Module::Build.invoke(:force => true, :'target-dir' => File.join(Dir.pwd, 'pkg'))
-    puts "Module built: #{path}"
-  rescue LoadError
-    system('pdk build --force')
-  end
+  path = PDK::Module::Build.invoke(:force => true, :'target-dir' => File.join(Dir.pwd, 'pkg'))
+  puts "Module built: #{path}"
 end
 
 desc 'Clean a built module package'

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -103,13 +103,13 @@ end
 
 desc 'Build puppet module package'
 task :build do
-  # This will be deprecated once puppet-module is a face.
   begin
-    Gem::Specification.find_by_name('puppet-module')
-  rescue Gem::LoadError, NoMethodError
-    require 'puppet/face'
-    pmod = Puppet::Face['module', :current]
-    pmod.build('./')
+    require 'pdk/module/build'
+
+    path = PDK::Module::Build.invoke(:force => true, :'target-dir' => File.join(Dir.pwd, 'pkg'))
+    puts "Module built: #{path}"
+  rescue LoadError
+    system('pdk build --force')
   end
 end
 

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -6,6 +6,7 @@ require 'pathname'
 require 'puppetlabs_spec_helper/version'
 require 'puppetlabs_spec_helper/tasks/beaker'
 require 'puppetlabs_spec_helper/tasks/fixtures'
+require 'English'
 
 # optional gems
 begin
@@ -103,10 +104,39 @@ end
 
 desc 'Build puppet module package'
 task :build do
-  require 'pdk/module/build'
+  if Gem::Specification.find_by_name('puppet').version < Gem::Version.new('6.0.0')
+    Rake::Task['build:pmt'].invoke
+  else
+    Rake::Task['build:pdk'].invoke
+  end
+end
 
-  path = PDK::Module::Build.invoke(:force => true, :'target-dir' => File.join(Dir.pwd, 'pkg'))
-  puts "Module built: #{path}"
+namespace :build do
+  desc 'Build Puppet module package with PMT (Puppet < 6.0.0 only)'
+  task :pmt do
+    require 'puppet/face'
+
+    pmod = Puppet::Face['module', :current]
+    pmod.build('./')
+  end
+
+  desc 'Build Puppet module with PDK'
+  task :pdk do
+    begin
+      require 'pdk/module/build'
+
+      path = PDK::Module::Build.invoke(:force => true, :'target-dir' => File.join(Dir.pwd, 'pkg'))
+      puts "Module built: #{path}"
+    rescue LoadError
+      _ = `pdk --version`
+      unless $CHILD_STATUS.success?
+        $stderr.puts 'Unable to build module. Please install PDK or add the `pdk` gem to your Gemfile.'
+        abort
+      end
+
+      system('pdk build --force')
+    end
+  end
 end
 
 desc 'Clean a built module package'

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'puppet-lint', '~> 2.0'
   spec.add_runtime_dependency 'puppet-syntax', '~> 2.0'
   spec.add_runtime_dependency 'rspec-puppet', '~> 2.0'
+  spec.add_runtime_dependency 'pdk', '~> 1.7.1'
 
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'pry'

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'puppet-lint', '~> 2.0'
   spec.add_runtime_dependency 'puppet-syntax', '~> 2.0'
   spec.add_runtime_dependency 'rspec-puppet', '~> 2.0'
-  spec.add_runtime_dependency 'pdk', '~> 1.7.1'
 
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'pry'


### PR DESCRIPTION
Attempt to load the PDK gem first in order to use PDK as a library. If
that fails, fall back to executing `pdk build`.

*Note* This depends on PDK 1.7.1 being released and so shouldn't be
merged until then.