### PR TITLE
Added tasks to rspec pattern.

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -24,7 +24,7 @@ end
 
 task default: [:help]
 
-pattern = 'spec/{aliases,classes,defines,unit,functions,hosts,integration,plans,type_aliases,types}/**/*_spec.rb'
+pattern = 'spec/{aliases,classes,defines,functions,hosts,integration,plans,tasks,type_aliases,types,unit}/**/*_spec.rb'
 
 RSpec::Core::RakeTask.new(:spec_standalone) do |t, args|
   t.rspec_opts = ['--color']


### PR DESCRIPTION
While I have yet to see anyone testing ruby tasks, I see no reason why we should prevent that.