### PR TITLE
(MODULES-7273) - Raise error when fixture ref invalid

### DIFF
--- a/lib/puppetlabs_spec_helper/tasks/fixtures.rb
+++ b/lib/puppetlabs_spec_helper/tasks/fixtures.rb
@@ -166,7 +166,8 @@ module PuppetlabsSpecHelper::Tasks::FixtureHelpers
     else
       raise "Unfortunately #{scm} is not supported yet"
     end
-    system("#{scm} #{args.flatten.join ' '}", chdir: target)
+    result = system("#{scm} #{args.flatten.join ' '}", chdir: target)
+    raise "Invalid ref #{ref} for #{target}" unless result
   end
 
   def valid_repo?(scm, target, remote)


### PR DESCRIPTION
Addresses the issue of tests running even when an invalid git reference is supplied. It appears to default to using master when this occurs instead of throwing a runtime error.