### PR TITLE
(PDK-997) Remove Dir.chdir call from check:test_file task

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -293,13 +293,10 @@ namespace :check do
 
   desc 'Fails if .pp files present in tests folder'
   task :test_file do
-    if Dir.exist?('tests')
-      Dir.chdir('tests')
-      ppfiles = Dir['*.pp']
-      unless ppfiles.empty?
-        puts ppfiles
-        raise '.pp files present in tests folder; Move them to an examples folder following the new convention'
-      end
+    ppfiles = Dir[File.join('tests', '**', '*.pp')]
+    unless ppfiles.empty?
+      puts ppfiles
+      raise '.pp files present in tests folder; Move them to an examples folder following the new convention'
     end
   end
 

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'yard'
   spec.add_development_dependency 'gettext-setup', '~> 0.29'
+  spec.add_development_dependency 'fakefs', '~> 0.13.3'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,9 +21,19 @@ if ENV['COVERAGE'] == 'yes'
   end
 end
 
+require 'fakefs/spec_helpers'
+
 require 'puppetlabs_spec_helper/puppet_spec_helper'
 require 'puppetlabs_spec_helper/puppetlabs_spec/puppet_internals'
 require 'puppetlabs_spec_helper/rake_tasks'
+
+RSpec.shared_context 'rake task', type: :task do
+  subject(:task) { Rake::Task[task_name] }
+
+  include FakeFS::SpecHelpers
+
+  let(:task_name) { self.class.top_level_description.sub(%r{\Arake }, '') }
+end
 
 # configure RSpec after including all the code
 RSpec.configure do |config|
@@ -31,4 +41,6 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
   config.mock_with :rspec
+
+  config.include_context 'rake task', type: :task
 end

--- a/spec/unit/puppetlabs_spec_helper/tasks/check_test_file_spec.rb
+++ b/spec/unit/puppetlabs_spec_helper/tasks/check_test_file_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe 'rake check:test_file', type: :task do
+  context 'when there are .pp files under tests/' do
+    before(:each) do
+      test_files.each do |f|
+        FileUtils.mkdir_p(File.dirname(f))
+        FileUtils.touch(f)
+      end
+    end
+
+    let(:test_files) do
+      [
+        File.join(Dir.pwd, 'tests', 'an_example.pp'),
+        File.join(Dir.pwd, 'tests', 'deep', 'directory', 'structure', 'another_example.pp'),
+      ]
+    end
+
+    it 'raises an error' do
+      expected_output = test_files.join("\n")
+
+      expect { task.execute }
+        .to raise_error(%r{pp files present in tests folder})
+        .and output(a_string_including(expected_output)).to_stdout
+    end
+  end
+
+  context 'when there are no .pp files under tests/' do
+    before(:each) do
+      FileUtils.mkdir('tests')
+    end
+
+    it 'runs without raising an error' do
+      expect { task.execute }.not_to raise_error
+    end
+  end
+
+  context 'when there is no tests/ directory' do
+    it 'runs without raising an error' do
+      expect { task.execute }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
This `chdir` breaks the isolation of the rake task and affects the
behaviour of other tasks that are invoked in it in the same `rake`
execution.

Rather than modify the task so that it changes back to the parent
directory after the task has finished, we can just remove the `chdir`
entirely and just change the glob to look for files in the directory.

This PR also adds some basic unit tests for the `check:test_file` task.