### PR TITLE
(PDK-1199) Honour .{pdk,git}ignore in check:symlinks rake task

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -89,6 +89,7 @@ Style/Documentation:
     - 'lib/puppetlabs_spec_helper/puppetlabs_spec/puppet_internals.rb'
     - 'lib/puppetlabs_spec_helper/tasks/beaker.rb'
     - 'lib/puppetlabs_spec_helper/tasks/fixtures.rb'
+    - 'lib/puppetlabs_spec_helper/tasks/check_symlinks.rb'
 
 # Offense count: 1
 Style/DoubleNegation:

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -6,6 +6,7 @@ require 'pathname'
 require 'puppetlabs_spec_helper/version'
 require 'puppetlabs_spec_helper/tasks/beaker'
 require 'puppetlabs_spec_helper/tasks/fixtures'
+require 'puppetlabs_spec_helper/tasks/check_symlinks'
 require 'English'
 
 # optional gems
@@ -284,7 +285,7 @@ end
 namespace :check do
   desc 'Fails if symlinks are present in directory'
   task :symlinks do
-    symlinks = check_directory_for_symlinks
+    symlinks = PuppetlabsSpecHelper::Tasks::CheckSymlinks.new.check
     unless symlinks.empty?
       symlinks.each { |r| puts "Symlink found: #{r} => #{r.readlink}" }
       raise 'Symlink(s) exist within this directory'

--- a/lib/puppetlabs_spec_helper/tasks/check_symlinks.rb
+++ b/lib/puppetlabs_spec_helper/tasks/check_symlinks.rb
@@ -1,0 +1,49 @@
+require 'pathspec'
+
+module PuppetlabsSpecHelper; end
+module PuppetlabsSpecHelper::Tasks; end
+
+class PuppetlabsSpecHelper::Tasks::CheckSymlinks
+  DEFAULT_IGNORED = [
+    '/.git/',
+    '/.bundle/',
+    '/vendor/',
+  ].freeze
+
+  IGNORE_LIST_FILES = [
+    '.pdkignore',
+    '.gitignore',
+  ].freeze
+
+  def check(dir = Dir.pwd)
+    dir = Pathname.new(dir) unless dir.is_a?(Pathname)
+    results = []
+
+    dir.each_child(true) do |child|
+      next if ignored?(child.to_s)
+
+      if child.symlink?
+        results << child
+      elsif child.directory? && child.basename.to_s !~ %r{^(\.git|\.?bundle)$}
+        results.concat(check(child))
+      end
+    end
+
+    results
+  end
+
+  def ignored?(path)
+    path = path.to_s + '/' if File.directory?(path)
+
+    !ignore_pathspec.match_paths([path], Dir.pwd).empty?
+  end
+
+  def ignore_pathspec
+    @ignore_pathspec ||= PathSpec.new(DEFAULT_IGNORED).tap do |pathspec|
+      IGNORE_LIST_FILES.each do |f|
+        next unless File.file?(f) && File.readable?(f)
+        File.open(f, 'r') { |fd| pathspec.add(fd) }
+      end
+    end
+  end
+end

--- a/lib/puppetlabs_spec_helper/tasks/fixtures.rb
+++ b/lib/puppetlabs_spec_helper/tasks/fixtures.rb
@@ -261,21 +261,6 @@ module PuppetlabsSpecHelper::Tasks::FixtureHelpers
     end
     @max_thread_limit
   end
-
-  def check_directory_for_symlinks(dir = '.')
-    dir = Pathname.new(dir) unless dir.is_a?(Pathname)
-    results = []
-
-    dir.each_child(true) do |child|
-      if child.symlink?
-        results << child
-      elsif child.directory? && child.basename.to_s !~ %r{(^\.git$|^\.?bundle$)}
-        results.concat(check_directory_for_symlinks(child))
-      end
-    end
-
-    results
-  end
 end
 include PuppetlabsSpecHelper::Tasks::FixtureHelpers
 

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'puppet-lint', '~> 2.0'
   spec.add_runtime_dependency 'puppet-syntax', '~> 2.0'
   spec.add_runtime_dependency 'rspec-puppet', '~> 2.0'
+  spec.add_runtime_dependency 'pathspec', '~> 0.2.1'
 
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'pry'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,12 @@ end
 
 require 'fakefs/spec_helpers'
 
+FakeFS::Pathname.class_eval do
+  def symlink?
+    File.symlink?(@path)
+  end
+end
+
 require 'puppetlabs_spec_helper/puppet_spec_helper'
 require 'puppetlabs_spec_helper/puppetlabs_spec/puppet_internals'
 require 'puppetlabs_spec_helper/rake_tasks'

--- a/spec/unit/puppetlabs_spec_helper/tasks/check_symlinks_spec.rb
+++ b/spec/unit/puppetlabs_spec_helper/tasks/check_symlinks_spec.rb
@@ -1,0 +1,160 @@
+require 'spec_helper'
+
+describe 'rake check:symlinks', type: :task do
+  before(:each) do
+    test_files.each do |f|
+      FileUtils.mkdir_p(File.dirname(f))
+      FileUtils.touch(f)
+    end
+
+    symlinks.each do |link, target|
+      FileUtils.mkdir_p(File.dirname(link))
+      FileUtils.ln_s(target, link)
+    end
+  end
+
+  let(:test_files) { [] }
+  let(:symlinks) { {} }
+  let(:expected_output) do
+    symlinks.map { |link, target| "Symlink found: #{link} => #{target}" }.join("\n")
+  end
+
+  context 'when there are no files' do
+    it 'runs without raising an error' do
+      expect { task.execute }.not_to raise_error
+    end
+  end
+
+  context 'when there are regular files' do
+    let(:test_files) do
+      [
+        File.join(Dir.pwd, 'files', 'a_file.pp'),
+        File.join(Dir.pwd, 'files', 'another_file.pp'),
+      ]
+    end
+
+    it 'runs without raising an error' do
+      expect { task.execute }.not_to raise_error
+    end
+  end
+
+  context 'when there is a symlink present' do
+    let(:test_files) do
+      [
+        File.join(Dir.pwd, 'files', 'a_file.pp'),
+      ]
+    end
+
+    let(:symlinks) do
+      {
+        File.join(Dir.pwd, 'files', 'a_symlink.pp') => File.join(Dir.pwd, 'files', 'a_file.pp'),
+      }
+    end
+
+    it 'raises an error' do
+      expect { task.execute }
+        .to raise_error(%r{symlink\(s\) exist}i)
+        .and output(a_string_including(expected_output)).to_stdout
+    end
+  end
+
+  context 'when there are symlinks under .git/' do
+    let(:test_files) do
+      [
+        File.join(Dir.pwd, 'files', 'a_file.pp'),
+      ]
+    end
+
+    let(:symlinks) do
+      {
+        File.join(Dir.pwd, '.git', 'a_symlink.pp') => File.join(Dir.pwd, 'files', 'a_file.pp'),
+      }
+    end
+
+    it 'runs without raising an error' do
+      expect { task.execute }.not_to raise_error
+    end
+  end
+
+  context 'when there are symlinks under .bundle/' do
+    let(:test_files) do
+      [
+        File.join(Dir.pwd, 'files', 'a_file.pp'),
+      ]
+    end
+
+    let(:symlinks) do
+      {
+        File.join(Dir.pwd, '.bundle', 'a_symlink.pp') => File.join(Dir.pwd, 'files', 'a_file.pp'),
+      }
+    end
+
+    it 'runs without raising an error' do
+      expect { task.execute }.not_to raise_error
+    end
+  end
+
+  context 'when there are symlinks under vendor/' do
+    let(:test_files) do
+      [
+        File.join(Dir.pwd, 'files', 'a_file.pp'),
+      ]
+    end
+
+    let(:symlinks) do
+      {
+        File.join(Dir.pwd, 'vendor', 'a_symlink.pp') => File.join(Dir.pwd, 'files', 'a_file.pp'),
+      }
+    end
+
+    it 'runs without raising an error' do
+      expect { task.execute }.not_to raise_error
+    end
+  end
+
+  context 'when there are symlinks under a directory listed in .gitignore' do
+    before(:each) do
+      File.write(File.join(Dir.pwd, '.gitignore'), "a_directory/\n")
+    end
+
+    let(:test_files) do
+      [
+        File.join(Dir.pwd, 'files', 'a_file.pp'),
+      ]
+    end
+
+    let(:symlinks) do
+      {
+        File.join(Dir.pwd, 'a_directory', 'a_symlink.pp') => File.join(Dir.pwd, 'files', 'a_file.pp'),
+      }
+    end
+
+    it 'runs without raising an error' do
+      expect { task.execute }.not_to raise_error
+    end
+  end
+
+  context 'when there are symlinks under a directory listed in .pdkignore' do
+    before(:each) do
+      File.open(File.join(Dir.pwd, '.pdkignore'), 'w') do |f|
+        f.puts '/another_directory/'
+      end
+    end
+
+    let(:test_files) do
+      [
+        File.join(Dir.pwd, 'files', 'a_file.pp'),
+      ]
+    end
+
+    let(:symlinks) do
+      {
+        File.join(Dir.pwd, 'another_directory', 'a_symlink.pp') => File.join(Dir.pwd, 'files', 'a_file.pp'),
+      }
+    end
+
+    it 'runs without raising an error' do
+      expect { task.execute }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
Introduces pathspec as a dependency (pure ruby and is already
a dependency of PDK and Puppet so it shouldn't be an issue). Also moves
the symlink checking logic out of the existing helper module and into
its own class for easier isolation between test cases.