### PR TITLE
(MAINT) Add Plans Path Exclusion

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -202,6 +202,7 @@ PuppetSyntax.exclude_paths ||= []
 PuppetSyntax.exclude_paths << 'spec/fixtures/**/*'
 PuppetSyntax.exclude_paths << 'pkg/**/*'
 PuppetSyntax.exclude_paths << 'vendor/**/*'
+PuppetSyntax.exclude_paths << 'plans/*'
 if Puppet.version.to_f < 4.0
   PuppetSyntax.exclude_paths << 'types/**/*'
 end


### PR DESCRIPTION
The Puppet parser cannot yet handle bolt plan syntax. Without this
exlusion adding plans to a module causes CI to fail in Appveyor because
the default lint checks will fail.