### PR TITLE
(maint) - Resolving bundler ruby version failure, updating tests to include puppet 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,17 @@ sudo: false
 language: ruby
 cache: bundler
 before_install:
-  # https://github.com/bundler/bundler/issues/3558
-  gem update bundler
+   bundle -v
 script: env COVERAGE=yes bundle exec rake
 matrix:
   fast_finish: true
   include:
+  - rvm: '2.5'
+    env: PUPPET_GEM_VERSION='~> 6.0'
+  - rvm: '2.4'
+    env: PUPPET_GEM_VERSION='~> 6.0'
+  - rvm: '2.3'
+    env: PUPPET_GEM_VERSION='~> 6.0'
   - rvm: '2.4'
     env: PUPPET_GEM_VERSION='~> 5.0'
   - rvm: '2.3'

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rspec-puppet', '~> 2.0'
   spec.add_runtime_dependency 'pathspec', '~> 0.2.1'
 
-  spec.add_development_dependency 'bundler', '~> 1.12'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'puppet'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Removing the pin from bundler as the older version of bundler does not support newer version of ruby. Also updating testing to include puppet 6.

This PR is required to allow #270 to progress.