### PR TITLE
Revert "(MODULES-8242) - Fix CI_SPEC_OPTIONS failing"

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -95,8 +95,8 @@ task :parallel_spec_standalone do |_t, args|
   else
     begin
       args = ['-t', 'rspec']
-      args += ENV['CI_SPEC_OPTIONS'].strip.split(' ') unless ENV['CI_SPEC_OPTIONS'].nil? || ENV['CI_SPEC_OPTIONS'].strip.empty?
-      args += Rake::FileList[pattern].to_a
+      args.push('--').concat(ENV['CI_SPEC_OPTIONS'].strip.split(' ')).push('--') unless ENV['CI_SPEC_OPTIONS'].nil? || ENV['CI_SPEC_OPTIONS'].strip.empty?
+      args.concat(Rake::FileList[pattern].to_a)
 
       ParallelTests::CLI.new.run(args)
     end


### PR DESCRIPTION
Reverts puppetlabs/puppetlabs_spec_helper#268 as this change breaks the documented behaviour. The `CI_SPEC_OPTIONS` environment variable is used for passing RSpec options into the rake task. In MODULES-8242 the user was attempting to pass parallel_tests options in this environment variable, which won't work and was mistaken for a bug. The behaviour now means that any RSpec options passed in this environment variable will cause the task to fail where it previously worked.

We should revert this change and then extend the logic to pass in parallel_tests options in a separate environment variable, split and push onto the `args` array before the options from `CI_SPEC_OPTIONS`.

/cc @scotje