### PR TITLE
(maint) load rake tasks from optional libraries

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -16,6 +16,24 @@ rescue LoadError
   # ignore
 end
 
+begin
+  require 'puppet_blacksmith/rake_tasks'
+rescue LoadError
+  # ignore
+end
+
+begin
+  require 'github_changelog_generator/task'
+rescue LoadError
+  # ignore
+end
+
+begin
+  require 'puppet-strings/tasks'
+rescue LoadError
+  # ignore
+end
+
 parallel_tests_loaded = false
 begin
   require 'parallel_tests'


### PR DESCRIPTION
This removes the need for the same loading code in pdk-templates at
https://github.com/puppetlabs/pdk-templates/blob/7281db56ead0feeacbc70e5d5dfb3bb885c554ba/moduleroot/Rakefile.erb#L13-L16

Note that `puppet-syntax/tasks/puppet-syntax` was already loaded in this
file further down.