### PR TITLE
Remove `--color` from everywhere, use RSpec default detection instead

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --format documentation
---color
 --order rand

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -29,7 +29,7 @@ task default: [:help]
 pattern = 'spec/{aliases,classes,defines,functions,hosts,integration,plans,tasks,type_aliases,types,unit}/**/*_spec.rb'
 
 RSpec::Core::RakeTask.new(:spec_standalone) do |t, args|
-  t.rspec_opts = ['--color']
+  t.rspec_opts = []
   t.rspec_opts << ENV['CI_SPEC_OPTIONS'] unless ENV['CI_SPEC_OPTIONS'].nil?
   if ENV['CI_NODE_TOTAL'] && ENV['CI_NODE_INDEX']
     ci_total = ENV['CI_NODE_TOTAL'].to_i

--- a/lib/puppetlabs_spec_helper/tasks/beaker.rb
+++ b/lib/puppetlabs_spec_helper/tasks/beaker.rb
@@ -59,7 +59,7 @@ end
 
 class SetupBeaker
   def self.setup_beaker(t)
-    t.rspec_opts = ['--color']
+    t.rspec_opts = []
     t.pattern = 'spec/acceptance'
     # TEST_TIERS env variable is a comma separated list of tiers to run. e.g. low, medium, high
     if ENV['TEST_TIERS']

--- a/spec/watchr.rb
+++ b/spec/watchr.rb
@@ -24,7 +24,7 @@ end
 
 def run_spec_test(file)
   if File.exist? file
-    result = run "rspec --format p --color #{file}"
+    result = run "rspec --format p #{file}"
     growl result.split("\n").last
     puts result
   else


### PR DESCRIPTION
RSpec 3 defaults to using color when possible, and people can override
this setting in their `$HOME\.rspec` if required.

This fixes #170