### PR TITLE
Download forge modules in parallel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,11 +7,12 @@ gemspec
 group :development do
   gem 'codecov'
   gem 'github_changelog_generator' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.0')
+  gem 'pry'
   gem 'puppet', ENV['PUPPET_GEM_VERSION'] || ENV['PUPPET_VERSION'] || '~> 4.0'
   gem 'simplecov', '~> 0'
   gem 'simplecov-console'
   if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
-    gem 'rubocop', '< 0.50'
+    gem 'rubocop', '= 0.49'
     gem 'rubocop-rspec', '~> 1'
   end
 end

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Host github.com
 
 ```
 
-Note: parallel downloads is only available for repositories and not forge modules.
+Note: parallel downloads are available for repositories and forge modules.
 
 ### Parallel tests
 It is also possible to use the `parallel_tests` Gem via the `:parallel_spec` Rake task to run rspec commands in parallel on groups of spec files.

--- a/spec/unit/puppetlabs_spec_helper/tasks/fixtures_spec.rb
+++ b/spec/unit/puppetlabs_spec_helper/tasks/fixtures_spec.rb
@@ -128,10 +128,10 @@ describe PuppetlabsSpecHelper::Tasks::FixtureHelpers do
         allow(YAML).to receive(:load_file).with('.fixtures.yml').and_return('fixtures' => { 'forge_modules' => { 'stdlib' => 'puppetlabs-stdlib' } })
         expect(subject.fixtures('forge_modules')).to eq('puppetlabs-stdlib' => {
                                                           'target' => 'spec/fixtures/modules/stdlib',
-                                                          'ref'    => nil,
+                                                          'ref' => nil,
                                                           'branch' => nil,
-                                                          'scm'    => nil,
-                                                          'flags'  => nil,
+                                                          'scm' => nil,
+                                                          'flags' => nil,
                                                           'subdir' => nil,
                                                         })
       end
@@ -143,14 +143,37 @@ describe PuppetlabsSpecHelper::Tasks::FixtureHelpers do
                                                                             'fixtures' => { 'forge_modules' => { 'stdlib' => 'puppetlabs-stdlib' } })
         expect(subject.fixtures('forge_modules')).to eq('puppetlabs-stdlib' => {
                                                           'target' => 'spec/fixtures/modules/stdlib',
-                                                          'ref'    => nil,
+                                                          'ref' => nil,
                                                           'branch' => nil,
-                                                          'scm'    => nil,
-                                                          'flags'  => '--module_repository=https://myforge.example.com/',
+                                                          'scm' => nil,
+                                                          'flags' => '--module_repository=https://myforge.example.com/',
                                                           'subdir' => nil,
                                                         })
       end
     end
+
+    context 'when file specifies repository fixtures' do
+      before(:each) do
+        allow(File).to receive(:exist?).with('.fixtures.yml').and_return true
+        allow(YAML).to receive(:load_file).with('.fixtures.yml').and_return(
+          'fixtures' => {
+            'repositories' => { 'stdlib' => 'https://github.com/puppetlabs/puppetlabs-stdlib.git' },
+          },
+        )
+      end
+
+      it 'returns the hash' do
+        expect(subject.repositories).to eq('https://github.com/puppetlabs/puppetlabs-stdlib.git' => {
+                                             'target' => 'spec/fixtures/modules/stdlib',
+                                             'ref' => nil,
+                                             'branch' => nil,
+                                             'scm' => nil,
+                                             'flags' => nil,
+                                             'subdir' => nil,
+                                           })
+      end
+    end
+
     context 'when file specifies puppet version' do
       def stub_fixtures(data)
         allow(File).to receive(:exist?).with('.fixtures.yml').and_return true


### PR DESCRIPTION
This improves the forge module download speed by at least 400% when multiple modules are specified in fixtures.yml. Git repositories were previously already using parallel downloads so this only fixes modules.

This also refactors the fixtures code by adding almost everything into a method and placed inside the fixtures module spec module. 


