### PR TITLE
(MODULES-8778) - Only use Bundler constant if it exists

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -9,7 +9,7 @@ require 'puppetlabs_spec_helper/tasks/check_symlinks'
 require 'English'
 
 # dont load beaker if litmus is present
-require 'puppetlabs_spec_helper/tasks/beaker' unless Bundler.rubygems.find_name('puppet_litmus').any?
+require 'puppetlabs_spec_helper/tasks/beaker' unless Object.const_defined?(:Bundler) && Bundler.rubygems.find_name('puppet_litmus').any?
 
 # optional gems
 begin


### PR DESCRIPTION
This PR fixes an issue seen by @ekohl where the following error was being thrown: 
`NameError: uninitialized constant Bundler`