### PR TITLE
(MAINT) Removes old rubies and puppet versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ os: linux
 dist: xenial
 language: ruby
 cache: bundler
-before_install:
-   bundle -v
+before_install: bundle -v
 script: env COVERAGE=yes bundle exec rake
 jobs:
   fast_finish: true
@@ -30,11 +29,5 @@ jobs:
     env: PUPPET_GEM_VERSION='~> 4.0'
   - rvm: '2.1'
     env: PUPPET_GEM_VERSION='~> 4.0'
-  - rvm: '2.1'
-    env: PUPPET_GEM_VERSION='~> 3.0'
-  - rvm: '2.0'
-    env: PUPPET_GEM_VERSION='~> 3.0'
-  - rvm: '1.9'
-    env: PUPPET_GEM_VERSION='~> 3.0'
 notifications:
   email: false


### PR DESCRIPTION
  * Support for puppet 3.0 and ruby 1.9 is long gone
    so it has been removed from test matrix.