### PR TITLE
(maint) Require pdk/util in build:pdk rake task

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -142,6 +142,7 @@ namespace :build do
   desc 'Build Puppet module with PDK'
   task :pdk do
     begin
+      require 'pdk/util'
       require 'pdk/module/build'
 
       path = PDK::Module::Build.invoke(:force => true, :'target-dir' => File.join(Dir.pwd, 'pkg'))


### PR DESCRIPTION
Temporary workaround for puppetlabs/pdk#770. We'll fix it in PDK of
course but we can also add this quick fix to puppetlabs_spec_helper and
release it a lot faster than we can do a new PDK release.

Using this branch of PSH:
```
$ bundle exec rake build:pdk
Module built: /home/tsharpe/code/puppetlabs/pdk/foo/pkg/tsharpe-foo-0.1.0.tar.gz
```