### PR TITLE
Accept `:tag` for consistency with r10k

### DIFF
--- a/lib/puppetlabs_spec_helper/tasks/fixtures.rb
+++ b/lib/puppetlabs_spec_helper/tasks/fixtures.rb
@@ -127,7 +127,7 @@ module PuppetlabsSpecHelper::Tasks::FixtureHelpers
 
         result[real_source] = {
           'target' => File.join(real_target, fixture),
-          'ref' => opts['ref'],
+          'ref' => opts['ref'] || opts['tag'],
           'branch' => opts['branch'],
           'scm' => opts['scm'],
           'flags' => opts['flags'],


### PR DESCRIPTION
This is a terrible way to do this. We should actually handle real branch/tag/etc like r10k does. This is intentionally undocumented so that it will only help catch user mistakes.