### PR TITLE
Support git fixture branches containing slashes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gemspec
 group :development do
   gem 'codecov'
   gem 'github_changelog_generator' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.0')
-  gem 'pry'
   gem 'puppet', ENV['PUPPET_GEM_VERSION'] || ENV['PUPPET_VERSION'] || '~> 4.0'
   gem 'simplecov', '~> 0'
   gem 'simplecov-console'

--- a/lib/puppetlabs_spec_helper/tasks/fixtures.rb
+++ b/lib/puppetlabs_spec_helper/tasks/fixtures.rb
@@ -198,7 +198,7 @@ module PuppetlabsSpecHelper::Tasks::FixtureHelpers
     when 'hg'
       args.push('update', '--clean', '-r', ref)
     when 'git'
-      args.push('reset', '--hard', ref)
+      args.push('reset', '--hard', "origin/#{ref}")
     else
       raise "Unfortunately #{scm} is not supported yet"
     end


### PR DESCRIPTION
Previously, checking out git feature branches containing slashes would
consistently fail.

This modifies the command to unambiguously point to origin.