### PR TITLE
Revert "Support git fixture branches containing slashes"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gemspec
 group :development do
   gem 'codecov'
   gem 'github_changelog_generator' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.0')
+  gem 'pry'
   gem 'puppet', ENV['PUPPET_GEM_VERSION'] || ENV['PUPPET_VERSION'] || '~> 4.0'
   gem 'simplecov', '~> 0'
   gem 'simplecov-console'

--- a/lib/puppetlabs_spec_helper/tasks/fixtures.rb
+++ b/lib/puppetlabs_spec_helper/tasks/fixtures.rb
@@ -198,7 +198,7 @@ module PuppetlabsSpecHelper::Tasks::FixtureHelpers
     when 'hg'
       args.push('update', '--clean', '-r', ref)
     when 'git'
-      args.push('reset', '--hard', "origin/#{ref}")
+      args.push('reset', '--hard', ref)
     else
       raise "Unfortunately #{scm} is not supported yet"
     end


### PR DESCRIPTION
This reverts commit 805ad89e350387ad41118bcff6db307ebdf3ce98 intoduced by #297. This is needed because it currently breaks fixtures using a specifiy git commit:

.fixtures.yml
```yaml
---
fixtures:
  repositories:
    stdlib:
      repo: https://github.com/puppetlabs/puppetlabs-stdlib.git
      ref: 91e71041d8065d3ac9ae6af2003ea55d05ead59e
```

With v2.14.1:
```
$ bundle exec gem list | grep spec_helper
puppetlabs_spec_helper (2.14.1)
$ bundle exec rake spec_prep
Cloning into 'spec/fixtures/modules/stdlib'...
remote: Enumerating objects: 21, done.
remote: Counting objects: 100% (21/21), done.
remote: Compressing objects: 100% (20/20), done.
remote: Total 14710 (delta 10), reused 5 (delta 1), pack-reused 14689
Receiving objects: 100% (14710/14710), 3.29 MiB | 3.37 MiB/s, done.
Resolving deltas: 100% (8293/8293), done.
HEAD is now at 91e7104 Merge pull request #1081 from ehom/master
I, [2020-01-30T16:29:09.394763 #95810]  INFO -- : Creating symlink from spec/fixtures/modules/test to /private/tmp/test
```

With current master:
```
$ bundle update | grep spec_helper
Fetching https://github.com/puppetlabs/puppetlabs_spec_helper.git
Using puppetlabs_spec_helper 2.14.1 from https://github.com/puppetlabs/puppetlabs_spec_helper.git (at 4fb572b@4fb572b)
$ bundle exec rake spec_prep
I, [2020-01-30T16:32:43.549252 #96150]  INFO -- : Creating symlink from spec/fixtures/modules/test to /private/tmp/test
Cloning into 'spec/fixtures/modules/stdlib'...
remote: Enumerating objects: 21, done.
remote: Counting objects: 100% (21/21), done.
remote: Compressing objects: 100% (20/20), done.
remote: Total 14710 (delta 10), reused 5 (delta 1), pack-reused 14689
Receiving objects: 100% (14710/14710), 3.29 MiB | 3.20 MiB/s, done.
Resolving deltas: 100% (8293/8293), done.
fatal: ambiguous argument 'origin/91e71041d8065d3ac9ae6af2003ea55d05ead59e': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
#<Thread:0x00007f826b1f8340@/Users/mbaur/.rvm/gems/ruby-2.6.3@test/bundler/gems/puppetlabs_spec_helper-4fb572b8eab2/lib/puppetlabs_spec_helper/tasks/fixtures.rb:289 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
	3: from /Users/mbaur/.rvm/gems/ruby-2.6.3@test/bundler/gems/puppetlabs_spec_helper-4fb572b8eab2/lib/puppetlabs_spec_helper/tasks/fixtures.rb:290:in `block (2 levels) in download_items'
	2: from /Users/mbaur/.rvm/gems/ruby-2.6.3@test/bundler/gems/puppetlabs_spec_helper-4fb572b8eab2/lib/puppetlabs_spec_helper/tasks/fixtures.rb:401:in `block (2 levels) in <top (required)>'
	1: from /Users/mbaur/.rvm/gems/ruby-2.6.3@test/bundler/gems/puppetlabs_spec_helper-4fb572b8eab2/lib/puppetlabs_spec_helper/tasks/fixtures.rb:340:in `download_repository'
/Users/mbaur/.rvm/gems/ruby-2.6.3@test/bundler/gems/puppetlabs_spec_helper-4fb572b8eab2/lib/puppetlabs_spec_helper/tasks/fixtures.rb:206:in `revision': Invalid ref 91e71041d8065d3ac9ae6af2003ea55d05ead59e for spec/fixtures/modules/stdlib (RuntimeError)
rake aborted!
Invalid ref 91e71041d8065d3ac9ae6af2003ea55d05ead59e for spec/fixtures/modules/stdlib
/Users/mbaur/.rvm/gems/ruby-2.6.3@test/bundler/gems/puppetlabs_spec_helper-4fb572b8eab2/lib/puppetlabs_spec_helper/tasks/fixtures.rb:206:in `revision'
/Users/mbaur/.rvm/gems/ruby-2.6.3@test/bundler/gems/puppetlabs_spec_helper-4fb572b8eab2/lib/puppetlabs_spec_helper/tasks/fixtures.rb:340:in `download_repository'
/Users/mbaur/.rvm/gems/ruby-2.6.3@test/bundler/gems/puppetlabs_spec_helper-4fb572b8eab2/lib/puppetlabs_spec_helper/tasks/fixtures.rb:401:in `block (2 levels) in <top (required)>'
/Users/mbaur/.rvm/gems/ruby-2.6.3@test/bundler/gems/puppetlabs_spec_helper-4fb572b8eab2/lib/puppetlabs_spec_helper/tasks/fixtures.rb:290:in `block (2 levels) in download_items'
Tasks: TOP => spec_prep
(See full trace by running task with --trace)
```

I think this error got introduced by a misunderstanding of the `ref` parameter which @trevor-vaughan thought should work with feature branches containing a `/`. The [documentation](https://github.com/puppetlabs/puppetlabs_spec_helper#using-fixtures) doesn't talk about branches when it comes to the `ref` parameter. There actually is a separate `branch` parameter which also works with a branch name containing a `/`:

```
$ cat .fixtures.yml
---
fixtures:
  repositories:
    stdlib:
      repo: https://github.com/puppetlabs/puppetlabs-stdlib.git
      branch: 'pdksync_pdksync_heads/master-0-gabccfb1'
$ bundle exec gem list | grep spec_helper
puppetlabs_spec_helper (2.14.1)
$ rm -rf spec/fixtures/modules/* ; bundle exec rake spec_prep
Cloning into 'spec/fixtures/modules/stdlib'...
remote: Enumerating objects: 624, done.
remote: Counting objects: 100% (624/624), done.
remote: Compressing objects: 100% (519/519), done.
remote: Total 624 (delta 173), reused 200 (delta 85), pack-reused 0
Receiving objects: 100% (624/624), 340.44 KiB | 1.24 MiB/s, done.
Resolving deltas: 100% (173/173), done.
I, [2020-01-30T16:51:39.807198 #99346]  INFO -- : Creating symlink from spec/fixtures/modules/test to /private/tmp/test
$ git -C spec/fixtures/modules/stdlib/ status
On branch pdksync_pdksync_heads/master-0-gabccfb1
Your branch is up to date with 'origin/pdksync_pdksync_heads/master-0-gabccfb1'.

nothing to commit, working tree clean
```