### PR TITLE
(GH-297) Don't allow git refs with forward slashes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -136,3 +136,7 @@ Style/SymbolArray:
   Description: Using percent style obscures symbolic intent of array's contents.
   Enabled: true
   EnforcedStyle: brackets
+
+# Enforce LF line endings, even when on Windows
+Layout/EndOfLine:
+  EnforcedStyle: lf

--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,18 @@ source 'https://rubygems.org'
 # Note that only ruby 1.9 compatible dependencies may go there, everything else needs to be documented and pulled in manually, and optionally by everyone who wants to use the extended features.
 gemspec
 
+def infer_puppet_version
+  # Infer the Puppet Gem version based on the Ruby Version
+  ruby_ver = Gem::Version.new(RUBY_VERSION.dup)
+  return '~> 6.0' if ruby_ver >= Gem::Version.new('2.5.0')
+  return '~> 5.0' if ruby_ver >= Gem::Version.new('2.4.0')
+  '~> 4.0'
+end
+
 group :development do
   gem 'codecov'
   gem 'github_changelog_generator' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.0')
-  gem 'puppet', ENV['PUPPET_GEM_VERSION'] || ENV['PUPPET_VERSION'] || '~> 4.0'
+  gem 'puppet', ENV['PUPPET_GEM_VERSION'] || ENV['PUPPET_VERSION'] || infer_puppet_version
   gem 'simplecov', '~> 0'
   gem 'simplecov-console'
   if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ variables for the spec run. These are:
   * ``TRUSTED_NODE_DATA``  _(Puppet 3.x, starting with 3.4)_ - set to "yes" to enable [the $facts hash and trusted node data](https://puppet.com/docs/puppet/3.8/lang_facts_and_builtin_vars.html#trusted-facts),
     which enabled ``$facts`` and ``$trusted`` hashes. This is equivalent to setting
     [trusted_node_data=true](https://puppet.com/docs/puppet/3.8/configuration.html#trustednodedata)
-    in puppet.conf.    
+    in puppet.conf.
   * ``STRINGIFY_FACTS``  _(Puppet 3.x, starting with 3.5)_  - set to "no" to enable [structured facts](http://docs.puppetlabs.com/facter/2.0/fact_overview.html#writing-structured-facts),
     otherwise leave unset to retain the current default behavior. This is equivalent to setting
     [stringify_facts=false](https://puppet.com/docs/puppet/3.8/configuration.html#stringifyfacts)
@@ -203,7 +203,7 @@ When specifying the repo source of the fixture you have a few options as to whic
 
  * `target` - the directory name to clone the repo into ie. `target: mymodule`  defaults to the repo name  (Optional)
  * `subdir` - directory to be removed from the cloned repo. Its contents will be moved to the root directory (Optional)
- * `ref` - used to specify the tag name like version hash of commit (Optional)
+ * `ref` - used to specify the tag name (like version) or commit hash to be checked out (Optional). Branch names should use the `branch` option instead.
 
    ```yaml
    ref: 1.0.0
@@ -389,7 +389,7 @@ environment variable``TEST_TIERS=high,medium``
 
 By default ``TEST_TIERS`` only accepts low, medium and high as valid tiers.  If you would like to use your own keywords to set the environment variable ``TEST_TIERS_ALLOWED``.
 
-For example: to use the keywords dev, rnd, staging and production you can set 
+For example: to use the keywords dev, rnd, staging and production you can set
 ``TEST_TIERS_ALLOWED=dev,rnd,staging,production``. Then you would be able to run tests marked ``tier_dev => true``, ``tier_production => true`` with ``TEST_TIERS=dev,production``
 
 Note, if the ``TEST_TIERS`` environment variable is set to empty string or nil, all tiers will be executed.

--- a/lib/puppetlabs_spec_helper/tasks/fixtures.rb
+++ b/lib/puppetlabs_spec_helper/tasks/fixtures.rb
@@ -125,17 +125,27 @@ module PuppetlabsSpecHelper::Tasks::FixtureHelpers
         real_target = eval('"' + opts['target'] + '"')
         real_source = eval('"' + opts['repo'] + '"')
 
-        result[real_source] = {
+        result[real_source] = validate_fixture_hash!(
           'target' => File.join(real_target, fixture),
-          'ref' => opts['ref'] || opts['tag'],
+          'ref'    => opts['ref'] || opts['tag'],
           'branch' => opts['branch'],
-          'scm' => opts['scm'],
-          'flags' => opts['flags'],
+          'scm'    => opts['scm'],
+          'flags'  => opts['flags'],
           'subdir' => opts['subdir'],
-        }
+        )
       end
     end
     result
+  end
+
+  def validate_fixture_hash!(hash)
+    # Can only validate git based scm
+    return hash unless hash['scm'] == 'git'
+
+    # Forward slashes in the ref aren't allowed. And is probably a branch name.
+    raise ArgumentError, "The ref for #{hash['target']} is invalid (Contains a forward slash). If this is a branch name, please use the 'branch' setting instead." if hash['ref'] =~ %r{\/}
+
+    hash
   end
 
   def include_repo?(version_range)

--- a/lib/puppetlabs_spec_helper/tasks/fixtures.rb
+++ b/lib/puppetlabs_spec_helper/tasks/fixtures.rb
@@ -198,7 +198,7 @@ module PuppetlabsSpecHelper::Tasks::FixtureHelpers
     when 'hg'
       args.push('update', '--clean', '-r', ref)
     when 'git'
-      args.push('reset', '--hard', "origin/#{ref}")
+      args.push('reset', '--hard', ref)
     else
       raise "Unfortunately #{scm} is not supported yet"
     end

--- a/spec/unit/puppetlabs_spec_helper/tasks/fixtures_spec.rb
+++ b/spec/unit/puppetlabs_spec_helper/tasks/fixtures_spec.rb
@@ -174,6 +174,27 @@ describe PuppetlabsSpecHelper::Tasks::FixtureHelpers do
       end
     end
 
+    context 'when file specifies repository fixtures with an invalid git ref' do
+      before(:each) do
+        allow(File).to receive(:exist?).with('.fixtures.yml').and_return true
+        allow(YAML).to receive(:load_file).with('.fixtures.yml').and_return(
+          'fixtures' => {
+            'repositories' => {
+              'stdlib' => {
+                'scm'  => 'git',
+                'repo' => 'https://github.com/puppetlabs/puppetlabs-stdlib.git',
+                'ref'  => 'this/is/a/branch',
+              },
+            },
+          },
+        )
+      end
+
+      it 'raises an ArgumentError' do
+        expect { subject.fixtures('repositories') }.to raise_error(ArgumentError)
+      end
+    end
+
     context 'when file specifies puppet version' do
       def stub_fixtures(data)
         allow(File).to receive(:exist?).with('.fixtures.yml').and_return true


### PR DESCRIPTION
Builds on #298 

Original PR was from @baurmatt

Previously if you added a ref with a forward slash, which is common in branch
names, this would fail in a strange way.  This commit adds early detection of
forward slashes and returns a helpful error message.