### PR TITLE
Remove all sub-folders from source repository / folder

### DIFF
--- a/lib/puppetlabs_spec_helper/tasks/fixtures.rb
+++ b/lib/puppetlabs_spec_helper/tasks/fixtures.rb
@@ -236,7 +236,7 @@ module PuppetlabsSpecHelper::Tasks::FixtureHelpers
     unless subdir.nil?
       Dir.mktmpdir do |tmpdir|
         FileUtils.mv(Dir.glob("#{target}/#{subdir}/{.[^\.]*,*}"), tmpdir)
-        FileUtils.rm_rf("#{target}/#{subdir}")
+        FileUtils.rm_rf(Dir.glob("#{target}/{.[^\.]*,*}"))
         FileUtils.mv(Dir.glob("#{tmpdir}/{.[^\.]*,*}"), target.to_s)
       end
     end


### PR DESCRIPTION
I assume we should remove all sub-folders from source repository to avoid folder names conflicts e.g. required subdir can contain folders with same name as root path of repository. I don't see a reason why we should keep them if we are interesting only in the subdirectory?
```
#<Thread:0x000055f554e03f90@/home/findmyname/.rvm/gems/ruby-2.5.3/gems/puppetlabs_spec_helper-2.14.1/lib/puppetlabs_spec_helper/tasks/fixtures.rb:296 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
	10: from /home/findmyname/.rvm/gems/ruby-2.5.3/gems/puppetlabs_spec_helper-2.14.1/lib/puppetlabs_spec_helper/tasks/fixtures.rb:303:in `block (3 levels) in <top (required)>'
	 9: from /home/findmyname/.rvm/gems/ruby-2.5.3/gems/puppetlabs_spec_helper-2.14.1/lib/puppetlabs_spec_helper/tasks/fixtures.rb:205:in `remove_subdirectory'
	 8: from /home/findmyname/.rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/tmpdir.rb:89:in `mktmpdir'
	 7: from /home/findmyname/.rvm/gems/ruby-2.5.3/gems/puppetlabs_spec_helper-2.14.1/lib/puppetlabs_spec_helper/tasks/fixtures.rb:208:in `block in remove_subdirectory'
	 6: from /home/findmyname/.rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/fileutils.rb:460:in `mv'
	 5: from /home/findmyname/.rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/fileutils.rb:1461:in `fu_each_src_dest'
	 4: from /home/findmyname/.rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/fileutils.rb:1470:in `fu_each_src_dest0'
	 3: from /home/findmyname/.rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/fileutils.rb:1470:in `each'
	 2: from /home/findmyname/.rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/fileutils.rb:1472:in `block in fu_each_src_dest0'
	 1: from /home/findmyname/.rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/fileutils.rb:1463:in `block in fu_each_src_dest'
/home/findmyname/.rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/fileutils.rb:465:in `block in mv': File exists - spec/fixtures/modules/showmax/manifests (Errno::EEXIST)
rake aborted!
```