### PR TITLE
Add Ruby 2.6/Puuppet6 to CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ script: env COVERAGE=yes bundle exec rake
 matrix:
   fast_finish: true
   include:
+  - rvm: '2.6'
+    env: PUPPET_GEM_VERSION='~> 6.0'
   - rvm: '2.5'
     env: PUPPET_GEM_VERSION='~> 6.0'
   - rvm: '2.4'


### PR DESCRIPTION
Ruby 2.6 isn't even the newest version, but many people use it locally
to run their tests. Based on that I think it makes sense to add it to
the CI matrix.