### PR TITLE
Add a check task

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -301,10 +301,7 @@ task :release_checks do
   else
     Rake::Task[:spec].invoke
   end
-  Rake::Task['check:symlinks'].invoke
-  Rake::Task['check:test_file'].invoke
-  Rake::Task['check:dot_underscore'].invoke
-  Rake::Task['check:git_ignore'].invoke
+  Rake::Task[:check].invoke
 end
 
 namespace :check do
@@ -344,6 +341,9 @@ namespace :check do
     end
   end
 end
+
+desc 'Run static pre release checks'
+task check: ['check:symlinks', 'check:test_file', 'check:dot_underscore', 'check:git_ignore']
 
 desc 'Display the list of available rake tasks'
 task :help do

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -284,7 +284,7 @@ task :compute_dev_version do
                     '%s-%s%04d-%s' % [version, 'r', build, sha] # legacy support code # rubocop:disable Style/FormatStringToken
                   else
                     '%s-%04d-%s' % [version, build, sha] # legacy support code # rubocop:disable Style/FormatStringToken
-                                end
+                  end
                 else
                   "#{version}-#{sha}"
                 end


### PR DESCRIPTION
This forms a combination of all check tasks which makes it easy to run it locally or in CI. The release_checks task is also modified to use it instead.