### PR TITLE
Add gemspec required_ruby_version

### DIFF
--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.4')
+
   spec.add_runtime_dependency 'mocha', '~> 1.0'
   spec.add_runtime_dependency 'pathspec', '>= 0.2.1', '< 1.1.0'
   spec.add_runtime_dependency 'puppet-lint', '~> 2.0'


### PR DESCRIPTION
This should have probably been included in https://github.com/puppetlabs/puppetlabs_spec_helper/pull/332