### PR TITLE
Only load beaker tasks if beaker-rspec is present

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -6,7 +6,6 @@ require 'rspec/core/rake_task'
 require 'tmpdir'
 require 'pathname'
 require 'puppetlabs_spec_helper/version'
-require 'puppetlabs_spec_helper/tasks/beaker'
 require 'puppetlabs_spec_helper/tasks/fixtures'
 require 'puppetlabs_spec_helper/tasks/check_symlinks'
 require 'English'
@@ -34,6 +33,14 @@ begin
   require 'puppet-strings/tasks'
 rescue LoadError
   # ignore
+end
+
+begin
+  require 'beaker-rspec/rake_task'
+rescue LoadError
+  # No beaker, no beaker rake tasks
+else
+  require 'puppetlabs_spec_helper/tasks/beaker'
 end
 
 parallel_tests_loaded = false

--- a/lib/puppetlabs_spec_helper/tasks/beaker.rb
+++ b/lib/puppetlabs_spec_helper/tasks/beaker.rb
@@ -53,6 +53,8 @@ module PuppetlabsSpecHelper::Tasks::BeakerHelpers
 end
 include PuppetlabsSpecHelper::Tasks::BeakerHelpers # legacy support code # rubocop:disable Style/MixinUsage
 
+Rake::Task[:beaker]&.clear
+
 desc 'Run beaker acceptance tests'
 RSpec::Core::RakeTask.new(:beaker) do |t|
   SetupBeaker.setup_beaker(t)


### PR DESCRIPTION
Not everyone is using beaker and there's no point in adding those rake tasks. This tries to load beaker-rspec. If that works, we can assume Beaker is present.

Currently a test because I haven't tested it. Just showing it as a response to https://github.com/puppetlabs/puppetlabs_spec_helper/pull/338#issuecomment-847115161.