### PR TITLE
(PDK-1717) Add guard clause to module path dir enum loop

### DIFF
--- a/lib/puppetlabs_spec_helper/module_spec_helper.rb
+++ b/lib/puppetlabs_spec_helper/module_spec_helper.rb
@@ -54,6 +54,7 @@ end
 
 # Add all spec lib dirs to LOAD_PATH
 components = module_path.split(File::PATH_SEPARATOR).collect do |dir|
+  next unless Dir.exist? dir
   Dir.entries(dir).reject { |f| f =~ %r{^\.} }.collect { |f| File.join(dir, f, 'spec', 'lib') }
 end
 components.flatten.each do |d|


### PR DESCRIPTION
Prior to this commit, If a non-existent directory is specified in
the `MODULEPATH` env var, it will cause the enumeration of module
paths to fail.

This commit performs a `Dir.exist?` check in that loop before any
subsequent unguarded / unrescued calls are made.

This issue manifested due to a conflict with the Linux package
`lmod` also using the `MODULEPATH` env var and populating it with
non-existent dir paths.