### PR TITLE
Configure puppet-lint to fail on warnings again

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -171,6 +171,7 @@ require 'puppet-lint/tasks/puppet-lint'
 # Must clear as it will not override the existing puppet-lint rake task since we require to import for
 # the PuppetLint::RakeTask
 Rake::Task[:lint].clear
+PuppetLint.configuration.fail_on_warnings = true
 # Utilize PuppetLint global configuration so that these settings can be tweaked by
 # spec_helper.rb in an individual module
 PuppetLint.configuration.relative = true


### PR DESCRIPTION
In a4bed8a2af6734744715178fd5f2b11e8aa7ded1 the checks were restructured to be reconfigurable but the `fail_on_warnings` setting was lost. This means the rake task isn't failing even if there are warnings.

Fixes: a4bed8a2af6734744715178fd5f2b11e8aa7ded1