### PR TITLE
Drop outdated future parser support

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -212,7 +212,6 @@ PuppetSyntax.exclude_paths << 'plans/**/*'
 if Puppet.version.to_f < 4.0
   PuppetSyntax.exclude_paths << 'types/**/*'
 end
-PuppetSyntax.future_parser = true if ENV['FUTURE_PARSER'] == 'yes'
 
 desc 'Check syntax of Ruby files and call :syntax and :metadata_lint'
 task :validate do


### PR DESCRIPTION
This is outdated and no longer supported by [puppet-syntax](https://github.com/voxpupuli/puppet-syntax/pull/120)