### PR TITLE
Fix check:git_ignore rake task for git >= 2.32.0

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -316,7 +316,7 @@ namespace :check do
 
   desc 'Fails if directories contain the files specified in .gitignore'
   task :git_ignore do
-    matched = `git ls-files --ignored --exclude-standard`
+    matched = `git ls-files --ignored --exclude-standard --cached`
     unless matched == ''
       puts matched
       raise 'File specified in .gitignore has been committed'


### PR DESCRIPTION
Since git 2.32.0, the task check:git_ignore failed with an error message: "fatal: ls-files -i must be used with either -o or -c". Fixed by adding `--cached` option to `git ls-files`.