### PR TITLE
Run the `strings:validate:reference` task during `validate`

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -228,6 +228,14 @@ task :validate do
       warn 'Skipping metadata validation; the metadata-json-lint gem was not found'
     end
   end
+
+  if File.exist?('REFERENCE.md')
+    if Rake::Task.task_defined?('strings:validate:reference')
+      Rake::Task['strings:validate:reference'].invoke
+    else
+      warn 'Skipping reference documentation validation; the puppet-strings gem was not found'
+    end
+  end
 end
 
 task :metadata do


### PR DESCRIPTION
If the documentation is not up-to-date or is broken, we want the validate task to fail so that we can more quickly detect inconsistencies and fix them early.

This was initially part of https://github.com/puppetlabs/puppetlabs-stdlib/pull/1239 but all projects can benefit from it.