### PR TITLE
Add rspec-github integration

### DIFF
--- a/lib/puppetlabs_spec_helper/module_spec_helper.rb
+++ b/lib/puppetlabs_spec_helper/module_spec_helper.rb
@@ -62,6 +62,10 @@ components.flatten.each do |d|
 end
 
 RSpec.configure do |c|
+  if ENV['GITHUB_ACTIONS'] == 'true'
+    c.formatter = 'RSpec::Github::Formatter'
+  end
+
   c.environmentpath = spec_path if Puppet.version.to_f >= 4.0
   c.module_path = module_path
   c.manifest_dir = File.join(fixture_path, 'manifests')

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -32,5 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'pathspec', '~> 1.0'
   spec.add_runtime_dependency 'puppet-lint', '~> 3.0'
   spec.add_runtime_dependency 'puppet-syntax', '~> 3.0'
+  spec.add_runtime_dependency 'rspec-github', '~> 2.0'
   spec.add_runtime_dependency 'rspec-puppet', '~> 2.0'
 end


### PR DESCRIPTION
This adds rspec-github as a dependency and at runtime it is optionally configured. The detection is the same as for Rubocop.

In https://github.com/voxpupuli/puppet-example/pull/22 I've showcased that this works:
![Screen Shot 2022-08-05 at 15 44 53](https://user-images.githubusercontent.com/155810/183090142-ce3b0366-160d-433e-9dd8-ef88a4e0977e.png)
