### PR TITLE
(CONT-237) Bump minimum Ruby version requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,41 +2,41 @@
 
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-def location_for(place_or_version, fake_version = nil)
-  git_url_regex = %r{\A(?<url>(?:https?|git)[:@][^#]*)(?:#(?<branch>.*))?}
-  file_url_regex = %r{\Afile://(?<path>.*)}
-
-  if place_or_version && (git_url = place_or_version.match(git_url_regex))
-    [fake_version, { git: git_url[:url], branch: git_url[:branch], require: false }].compact
-  elsif place_or_version && (file_url = place_or_version.match(file_url_regex))
-    ['>= 0', { path: File.expand_path(file_url[:path]), require: false }]
-  else
-    [place_or_version, { require: false }]
-  end
-end
-
-# Specify the global dependencies in puppetlabs_spec_helper.gemspec
-# Note that only ruby 1.9 compatible dependencies may go there, everything else needs to be documented and pulled in manually, and optionally by everyone who wants to use the extended features.
 gemspec
 
-def infer_puppet_version
-  # Infer the Puppet Gem version based on the Ruby Version
-  ruby_ver = Gem::Version.new(RUBY_VERSION.dup)
-  return '~> 7.0' if ruby_ver >= Gem::Version.new('2.7.0')
-  return '~> 6.0' if ruby_ver >= Gem::Version.new('2.5.0')
-  '~> 5.0'
+if ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', ENV['PUPPET_GEM_VERSION'], :require => false
+else
+  gem 'puppet', :require => false
 end
 
 group :development do
   gem 'codecov'
-  gem 'github_changelog_generator' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.0')
-  gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'] || ENV['PUPPET_VERSION'] || infer_puppet_version)
-  gem 'simplecov', '~> 0'
+  gem 'simplecov'
   gem 'simplecov-console'
-  if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.4')
-    gem 'rubocop', '0.57.2'
-    gem 'rubocop-rspec'
-  end
+
+  gem 'pry', require: false
+  gem 'pry-byebug', require: false
+  gem 'pry-stack_explorer', require: false
+
+  gem 'rake'
+  gem 'rspec', '~> 3.1'
+  gem 'rspec-its', '~> 1.0'
+  gem 'rubocop', '~> 1.6.1', require: false
+  gem 'rubocop-rspec', '~> 2.0.1', require: false
+  gem 'rubocop-performance', '~> 1.9.1', require: false
+
+  gem 'fakefs'
+  gem 'yard'
 end
 
-# vim:filetype=ruby
+
+# Evaluate Gemfile.local if it exists
+if File.exists? "#{__FILE__}.local"
+  eval(File.read("#{__FILE__}.local"), binding)
+end
+
+# Evaluate ~/.gemfile if it exists
+if File.exists?(File.join(Dir.home, '.gemfile'))
+  eval(File.read(File.join(Dir.home, '.gemfile')), binding)
+end

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -15,24 +15,22 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'http://github.com/puppetlabs/puppetlabs_spec_helper'
   spec.license       = 'Apache-2.0'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.files = Dir[
+    'README.md',
+    'LICENSE',
+    '.rubocop.yml',
+    'lib/**/*',
+    'bin/**/*',
+    'spec/**/*',
+  ]
+  spec.executables = Dir['bin/**/*'].map { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.4')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.7'.freeze)
 
   spec.add_runtime_dependency 'mocha', '~> 1.0'
-  spec.add_runtime_dependency 'pathspec', '>= 0.2.1', '< 1.1.0'
-  spec.add_runtime_dependency 'puppet-lint', '~> 2.0'
-  spec.add_runtime_dependency 'puppet-syntax', ['>= 2.0', '< 4']
+  spec.add_runtime_dependency 'pathspec', '~> 1.0'
+  spec.add_runtime_dependency 'puppet-lint', '~> 3.0'
+  spec.add_runtime_dependency 'puppet-syntax', '~> 3.0'
   spec.add_runtime_dependency 'rspec-puppet', '~> 2.0'
-
-  spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'fakefs', ['>= 0.13.3', '< 2']
-  spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'puppet'
-  spec.add_development_dependency 'rake', ['>= 10.0', '< 14']
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'yard'
 end


### PR DESCRIPTION
Primarily, this commit bumps the minimum required ruby version to 2.7.

Along with this change a number of dependencies have also been bumped so that they are inline with other gems.