### PR TITLE
(CONT-237) Rubocop updates

### DIFF
--- a/lib/puppetlabs_spec_helper/module_spec_helper.rb
+++ b/lib/puppetlabs_spec_helper/module_spec_helper.rb
@@ -53,9 +53,9 @@ if ENV['SIMPLECOV'] == 'yes'
 end
 
 # Add all spec lib dirs to LOAD_PATH
-components = module_path.split(File::PATH_SEPARATOR).collect do |dir|
+components = module_path.split(File::PATH_SEPARATOR).map do |dir|
   next unless Dir.exist? dir
-  Dir.entries(dir).reject { |f| f =~ %r{^\.} }.collect { |f| File.join(dir, f, 'spec', 'lib') }
+  Dir.entries(dir).reject { |f| f =~ %r{^\.} }.map { |f| File.join(dir, f, 'spec', 'lib') }
 end
 components.flatten.each do |d|
   $LOAD_PATH << d if FileTest.directory?(d) && !$LOAD_PATH.include?(d)

--- a/lib/puppetlabs_spec_helper/puppet_spec_helper.rb
+++ b/lib/puppetlabs_spec_helper/puppet_spec_helper.rb
@@ -48,55 +48,54 @@ require 'puppetlabs_spec_helper/puppetlabs_spec/files'
 begin
   require 'puppet/test/test_helper'
 rescue LoadError
+  # Continue gracefully
 end
 
 # This is just a utility class to allow us to isolate the various version-specific
 # branches of initialization logic into methods without polluting the global namespace.#
-module Puppet
-  class PuppetSpecInitializer
-    # This method is for initializing puppet state for testing for older versions
-    # of puppet that do not support the new TestHelper API.  As you can see,
-    # this involves explicitly modifying global variables, directly manipulating
-    # Puppet's Settings singleton object, and other fun implementation details
-    # that code external to puppet should really never know about.
-    def self.initialize_via_fallback_compatibility(config)
-      warn('Warning: you appear to be using an older version of puppet; spec_helper will use fallback compatibility mode.')
-      config.before :all do
-        # nothing to do for now
-      end
+class Puppet::PuppetSpecInitializer
+  # This method is for initializing puppet state for testing for older versions
+  # of puppet that do not support the new TestHelper API.  As you can see,
+  # this involves explicitly modifying global variables, directly manipulating
+  # Puppet's Settings singleton object, and other fun implementation details
+  # that code external to puppet should really never know about.
+  def self.initialize_via_fallback_compatibility(config)
+    warn('Warning: you appear to be using an older version of puppet; spec_helper will use fallback compatibility mode.')
+    config.before :all do
+      # nothing to do for now
+    end
 
-      config.after :all do
-        # nothing to do for now
-      end
+    config.after :all do
+      # nothing to do for now
+    end
 
-      config.before :each do
-        # these globals are set by Application
-        $puppet_application_mode = nil
-        $puppet_application_name = nil
+    config.before :each do
+      # these globals are set by Application
+      $puppet_application_mode = nil # rubocop:disable Style/GlobalVars
+      $puppet_application_name = nil # rubocop:disable Style/GlobalVars
 
-        # REVISIT: I think this conceals other bad tests, but I don't have time to
-        # fully diagnose those right now.  When you read this, please come tell me
-        # I suck for letting this float. --daniel 2011-04-21
-        Signal.stubs(:trap)
+      # REVISIT: I think this conceals other bad tests, but I don't have time to
+      # fully diagnose those right now.  When you read this, please come tell me
+      # I suck for letting this float. --daniel 2011-04-21
+      Signal.stubs(:trap)
 
-        # Set the confdir and vardir to gibberish so that tests
-        # have to be correctly mocked.
-        Puppet[:confdir] = '/dev/null'
-        Puppet[:vardir] = '/dev/null'
+      # Set the confdir and vardir to gibberish so that tests
+      # have to be correctly mocked.
+      Puppet[:confdir] = '/dev/null'
+      Puppet[:vardir] = '/dev/null'
 
-        # Avoid opening ports to the outside world
-        Puppet.settings[:bindaddress] = '127.0.0.1'
-      end
+      # Avoid opening ports to the outside world
+      Puppet.settings[:bindaddress] = '127.0.0.1'
+    end
 
-      config.after :each do
-        Puppet.settings.clear
+    config.after :each do
+      Puppet.settings.clear
 
-        Puppet::Node::Environment.clear
-        Puppet::Util::Storage.clear
-        Puppet::Util::ExecutionStub.reset if Puppet::Util.constants.include? 'ExecutionStub'
+      Puppet::Node::Environment.clear
+      Puppet::Util::Storage.clear
+      Puppet::Util::ExecutionStub.reset if Puppet::Util.constants.include? 'ExecutionStub'
 
-        PuppetlabsSpec::Files.cleanup
-      end
+      PuppetlabsSpec::Files.cleanup
     end
   end
 end
@@ -104,6 +103,8 @@ end
 # JJM Hack to make the stdlib tests run in Puppet 2.6 (See puppet commit cf183534)
 unless Puppet.constants.include? 'Test'
   module Puppet::Test
+    # This is a stub class to allow the stdlib tests to run in Puppet 2.6
+    # This class will be removed in another commit.
     class LogCollector
       def initialize(logs)
         @logs = logs

--- a/lib/puppetlabs_spec_helper/puppetlabs_spec/files.rb
+++ b/lib/puppetlabs_spec_helper/puppetlabs_spec/files.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable Style/GlobalVars # TODO: investigate the use of instance variables
+
 require 'fileutils'
 require 'tempfile'
 require 'pathname'
@@ -20,7 +22,7 @@ module PuppetlabsSpec::Files
 
   def self.cleanup
     $global_tempfiles ||= []
-    while path = $global_tempfiles.pop
+    while (path = $global_tempfiles.pop)
       raise "Not deleting tmpfile #{path} outside regular tmpdir" unless in_tmp(path)
 
       begin

--- a/lib/puppetlabs_spec_helper/puppetlabs_spec/fixtures.rb
+++ b/lib/puppetlabs_spec_helper/puppetlabs_spec/fixtures.rb
@@ -14,8 +14,8 @@ module PuppetlabsSpec::Fixtures
   # <project>/spec/fixture/unit/facter/foo
   def my_fixture_dir
     callers = caller
-    while line = callers.shift
-      next unless found = line.match(%r{/spec/(.*)_spec\.rb:})
+    while (line = callers.shift)
+      next unless (found = line.match(%r{/spec/(.*)_spec\.rb:}))
 
       return fixtures(found[1])
     end
@@ -47,7 +47,7 @@ module PuppetlabsSpec::Fixtures
       raise "fixture '#{glob}' for #{my_fixture_dir} had no files!"
     end
 
-    block_given? && files.each(&block)
+    block && files.each(&block)
     files
   end
 end

--- a/lib/puppetlabs_spec_helper/puppetlabs_spec/matchers.rb
+++ b/lib/puppetlabs_spec_helper/puppetlabs_spec/matchers.rb
@@ -5,20 +5,15 @@ require 'rspec/expectations'
 
 ########################################################################
 # Backward compatibility for Jenkins outdated environment.
-module RSpec
-  module Matchers
-    module BlockAliases
-      if method_defined?(:should) && !method_defined?(:to)
-        alias to should
-      end
-      if method_defined? :should_not
-        alias to_not should_not unless method_defined? :to_not
-        alias not_to should_not unless method_defined? :not_to
-      end
-    end
+module RSpec::Matchers::BlockAliases
+  if method_defined?(:should) && !method_defined?(:to)
+    alias to should
+  end
+  if method_defined? :should_not
+    alias to_not should_not unless method_defined? :to_not
+    alias not_to should_not unless method_defined? :not_to
   end
 end
-
 ########################################################################
 # Custom matchers...
 RSpec::Matchers.define :have_matching_element do |expected|

--- a/lib/puppetlabs_spec_helper/puppetlabs_spec/puppet_internals.rb
+++ b/lib/puppetlabs_spec_helper/puppetlabs_spec/puppet_internals.rb
@@ -4,74 +4,73 @@
 # 'puppetlabs_spec_helper/puppet_spec_helper' library
 require 'puppetlabs_spec_helper/puppet_spec_helper'
 
-module PuppetlabsSpec
-  module PuppetInternals
-    # parser_scope is intended to return a Puppet::Parser::Scope
-    # instance suitable for placing in a test harness with the intent of
-    # testing parser functions from modules.
-    def scope(parts = {})
-      RSpec.deprecate('scope', replacement: 'rspec-puppet 2.2.0 provides a scope property')
+# PuppetInternals provides a set of methods that interface
+# with internal puppet implementations.
+module PuppetlabsSpec::PuppetInternals
+  # parser_scope is intended to return a Puppet::Parser::Scope
+  # instance suitable for placing in a test harness with the intent of
+  # testing parser functions from modules.
+  def scope(parts = {})
+    RSpec.deprecate('scope', replacement: 'rspec-puppet 2.2.0 provides a scope property')
 
-      if %r{^2\.[67]}.match?(Puppet.version)
-        # loadall should only be necessary prior to 3.x
-        # Please note, loadall needs to happen first when creating a scope, otherwise
-        # you might receive undefined method `function_*' errors
-        Puppet::Parser::Functions.autoloader.loadall
-      end
-
-      scope_compiler = parts[:compiler] || compiler
-      scope_parent = parts[:parent] || scope_compiler.topscope
-      scope_resource = parts[:resource] || resource(type: :node, title: scope_compiler.node.name)
-
-      scope = if %r{^2\.[67]}.match?(Puppet.version)
-                Puppet::Parser::Scope.new(compiler: scope_compiler)
-              else
-                Puppet::Parser::Scope.new(scope_compiler)
-              end
-
-      scope.source = Puppet::Resource::Type.new(:node, 'foo')
-      scope.parent = scope_parent
-      scope
+    if %r{^2\.[67]}.match?(Puppet.version)
+      # loadall should only be necessary prior to 3.x
+      # Please note, loadall needs to happen first when creating a scope, otherwise
+      # you might receive undefined method `function_*' errors
+      Puppet::Parser::Functions.autoloader.loadall
     end
-    module_function :scope
 
-    def resource(parts = {})
-      resource_type = parts[:type] || :hostclass
-      resource_name = parts[:name] || 'testing'
-      Puppet::Resource::Type.new(resource_type, resource_name)
-    end
-    module_function :resource
+    scope_compiler = parts[:compiler] || compiler
+    scope_parent = parts[:parent] || scope_compiler.topscope
 
-    def compiler(parts = {})
-      compiler_node = parts[:node] || node
-      Puppet::Parser::Compiler.new(compiler_node)
-    end
-    module_function :compiler
+    scope = if %r{^2\.[67]}.match?(Puppet.version)
+              Puppet::Parser::Scope.new(compiler: scope_compiler)
+            else
+              Puppet::Parser::Scope.new(scope_compiler)
+            end
 
-    def node(parts = {})
-      node_name = parts[:name] || 'testinghost'
-      options = parts[:options] || {}
-      node_environment = if Puppet.version.to_f >= 4.0
-                           Puppet::Node::Environment.create(parts[:environment] || 'test', [])
-                         else
-                           Puppet::Node::Environment.new(parts[:environment] || 'test')
-                         end
-      options[:environment] = node_environment
-      Puppet::Node.new(node_name, options)
-    end
-    module_function :node
-
-    # Return a method instance for a given function.  This is primarily useful
-    # for rspec-puppet
-    def function_method(name, parts = {})
-      scope = parts[:scope] || scope()
-      # Ensure the method instance is defined by side-effect of checking if it
-      # exists.  This is a hack, but at least it's a hidden hack and not an
-      # exposed hack.
-      return nil unless Puppet::Parser::Functions.function(name)
-
-      scope.method("function_#{name}".intern)
-    end
-    module_function :function_method
+    scope.source = Puppet::Resource::Type.new(:node, 'foo')
+    scope.parent = scope_parent
+    scope
   end
+  module_function :scope
+
+  def resource(parts = {})
+    resource_type = parts[:type] || :hostclass
+    resource_name = parts[:name] || 'testing'
+    Puppet::Resource::Type.new(resource_type, resource_name)
+  end
+  module_function :resource
+
+  def compiler(parts = {})
+    compiler_node = parts[:node] || node
+    Puppet::Parser::Compiler.new(compiler_node)
+  end
+  module_function :compiler
+
+  def node(parts = {})
+    node_name = parts[:name] || 'testinghost'
+    options = parts[:options] || {}
+    node_environment = if Puppet.version.to_f >= 4.0
+                         Puppet::Node::Environment.create(parts[:environment] || 'test', [])
+                       else
+                         Puppet::Node::Environment.new(parts[:environment] || 'test')
+                       end
+    options[:environment] = node_environment
+    Puppet::Node.new(node_name, options)
+  end
+  module_function :node
+
+  # Return a method instance for a given function.  This is primarily useful
+  # for rspec-puppet
+  def function_method(name, parts = {})
+    scope = parts[:scope] || scope()
+    # Ensure the method instance is defined by side-effect of checking if it
+    # exists.  This is a hack, but at least it's a hidden hack and not an
+    # exposed hack.
+    return nil unless Puppet::Parser::Functions.function(name)
+
+    scope.method("function_#{name}".to_sym)
+  end
+  module_function :function_method
 end

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -79,13 +79,11 @@ end
 
 desc 'Run spec tests and clean the fixtures directory if successful'
 task :spec do |_t, args|
-  begin
-    Rake::Task[:spec_prep].invoke
-    Rake::Task[:spec_standalone].invoke(*args.extras)
-    Rake::Task[:spec_clean].invoke
-  ensure
-    Rake::Task[:spec_clean_symlinks].invoke
-  end
+  Rake::Task[:spec_prep].invoke
+  Rake::Task[:spec_standalone].invoke(*args.extras)
+  Rake::Task[:spec_clean].invoke
+ensure
+  Rake::Task[:spec_clean_symlinks].invoke
 end
 
 desc 'Run spec tests with ruby simplecov code coverage'
@@ -98,13 +96,11 @@ end
 
 desc 'Run spec tests in parallel and clean the fixtures directory if successful'
 task :parallel_spec do |_t, args|
-  begin
-    Rake::Task[:spec_prep].invoke
-    Rake::Task[:parallel_spec_standalone].invoke(*args.extras)
-    Rake::Task[:spec_clean].invoke
-  ensure
-    Rake::Task[:spec_clean_symlinks].invoke
-  end
+  Rake::Task[:spec_prep].invoke
+  Rake::Task[:parallel_spec_standalone].invoke(*args.extras)
+  Rake::Task[:spec_clean].invoke
+ensure
+  Rake::Task[:spec_clean_symlinks].invoke
 end
 
 desc 'Parallel spec tests'
@@ -144,21 +140,19 @@ namespace :build do
 
   desc 'Build Puppet module with PDK'
   task :pdk do
-    begin
-      require 'pdk/util'
-      require 'pdk/module/build'
+    require 'pdk/util'
+    require 'pdk/module/build'
 
-      path = PDK::Module::Build.invoke(force: true, 'target-dir': File.join(Dir.pwd, 'pkg'))
-      puts "Module built: #{path}"
-    rescue LoadError
-      _ = `pdk --version`
-      unless $CHILD_STATUS.success?
-        warn 'Unable to build module. Please install PDK or add the `pdk` gem to your Gemfile.'
-        abort
-      end
-
-      system('pdk build --force')
+    path = PDK::Module::Build.invoke(force: true, 'target-dir': File.join(Dir.pwd, 'pkg'))
+    puts "Module built: #{path}"
+  rescue LoadError
+    _ = `pdk --version`
+    unless $CHILD_STATUS.success?
+      warn 'Unable to build module. Please install PDK or add the `pdk` gem to your Gemfile.'
+      abort
     end
+
+    system('pdk build --force')
   end
 end
 
@@ -183,15 +177,16 @@ PuppetLint.configuration.ignore_paths << 'spec/**/*.pp'
 PuppetLint.configuration.ignore_paths << 'tests/**/*.pp'
 PuppetLint.configuration.ignore_paths << 'types/**/*.pp'
 PuppetLint.configuration.ignore_paths << 'vendor/**/*.pp'
-puppet_lint_disable_checks = %w[
-  80chars
-  140chars
-  class_inherits_from_params_class
-  class_parameter_defaults
-  disable_autoloader_layout
-  documentation
-  single_quote_string_with_variables
+puppet_lint_disable_checks = [
+  '80chars',
+  '140chars',
+  'class_inherits_from_params_class',
+  'class_parameter_defaults',
+  'disable_autoloader_layout',
+  'documentation',
+  'single_quote_string_with_variables',
 ]
+
 puppet_lint_disable_checks.each do |check|
   PuppetLint.configuration.send("disable_#{check}")
 end
@@ -268,7 +263,7 @@ task :compute_dev_version do
   # If the branch is a release branch we append an 'r' into the new_version,
   # this is due to the release branch buildID conflicting with main branch when trying to push to the staging forge.
   # More info can be found at https://tickets.puppetlabs.com/browse/FM-6170
-  new_version = if build = (ENV['BUILD_NUMBER'] || ENV['TRAVIS_BUILD_NUMBER'])
+  new_version = if (build = (ENV['BUILD_NUMBER'] || ENV['TRAVIS_BUILD_NUMBER']))
                   if branch.eql? 'release'
                     '%s-%s%04d-%s' % [version, 'r', build, sha] # legacy support code # rubocop:disable Style/FormatStringToken
                   else
@@ -416,7 +411,7 @@ def create_gch_task(changelog_user = nil, changelog_project = nil, changelog_sin
         },
         'Added' => {
           'prefix' => '### Added',
-          'labels' => %w[feature enhancement],
+          'labels' => ['feature', 'enhancement'],
         },
         'Fixed' => {
           'prefix' => '### Fixed',

--- a/lib/puppetlabs_spec_helper/tasks/check_symlinks.rb
+++ b/lib/puppetlabs_spec_helper/tasks/check_symlinks.rb
@@ -2,9 +2,7 @@
 
 require 'pathspec'
 
-module PuppetlabsSpecHelper; end
-module PuppetlabsSpecHelper::Tasks; end
-
+# Helpers for validating symlinks.
 class PuppetlabsSpecHelper::Tasks::CheckSymlinks
   DEFAULT_IGNORED = [
     '/.git/',

--- a/lib/puppetlabs_spec_helper/tasks/fixtures.rb
+++ b/lib/puppetlabs_spec_helper/tasks/fixtures.rb
@@ -140,7 +140,7 @@ module PuppetlabsSpecHelper::Tasks::FixtureHelpers
         # rubocop:disable Security/Eval
         # TODO: Remove eval
         real_target = eval("\"#{opts['target']}\"", binding, __FILE__, __LINE__) # evaluating target reference in this context (see auto_symlink)
-        real_source = eval("\"#{opts['repo']}\"", binding, __FILE__, __LINE__) # evaluating repo reference in this context (see auto_symlink)t
+        real_source = eval("\"#{opts['repo']}\"", binding, __FILE__, __LINE__) # evaluating repo reference in this context (see auto_symlink)
 
         result[real_source] = validate_fixture_hash!(
           'target' => File.join(real_target, fixture),

--- a/spec/acceptance/smoke_spec.rb
+++ b/spec/acceptance/smoke_spec.rb
@@ -5,10 +5,10 @@ require 'open3'
 
 # some smoke tests to verify overall sanity
 RSpec.describe 'rake' do
-  before(:all) do
-    @output, @status = Open3.capture2e('rake', '--rakefile', 'spec/acceptance/fixtures/Rakefile', '-T')
+  let(:output) do
+    Open3.capture2e('rake', '--rakefile', 'spec/acceptance/fixtures/Rakefile', '-T')
   end
 
-  it { expect(@output).to match %r{spec_prep} }
-  it { expect(@status).to be_success }
+  it { expect(output[0]).to match %r{spec_prep} }
+  it { expect(output[1]).to be_success }
 end

--- a/spec/unit/puppetlabs_spec_helper/puppetlabs_spec/puppet_internals_spec.rb
+++ b/spec/unit/puppetlabs_spec_helper/puppetlabs_spec/puppet_internals_spec.rb
@@ -8,14 +8,14 @@ describe PuppetlabsSpec::PuppetInternals do
   end
 
   describe '.scope' do
-    let(:subject) { described_class.scope }
+    subject(:scope) { described_class.scope }
 
     it 'returns a Puppet::Parser::Scope instance' do
-      expect(subject).to be_a_kind_of Puppet::Parser::Scope
+      expect(scope).to be_a_kind_of Puppet::Parser::Scope
     end
 
     it 'is suitable for function testing' do
-      expect(subject.function_inline_template(['foo'])).to eq('foo')
+      expect(scope.function_inline_template(['foo'])).to eq('foo')
     end
 
     it 'accepts a compiler' do
@@ -25,21 +25,20 @@ describe PuppetlabsSpec::PuppetInternals do
     end
 
     it 'has a source set' do
-      scope = subject
       expect(scope.source).not_to be_nil
       expect(scope.source.name).to eq('foo')
     end
   end
 
   describe '.resource' do
-    let(:subject) { described_class.resource }
+    subject(:resource) { described_class.resource }
 
     it 'can have a defined type' do
       expect(described_class.resource(type: :node).type).to eq(:node)
     end
 
     it 'defaults to a type of hostclass' do
-      expect(subject.type).to eq(:hostclass)
+      expect(resource.type).to eq(:hostclass)
     end
 
     it 'can have a defined name' do
@@ -47,7 +46,7 @@ describe PuppetlabsSpec::PuppetInternals do
     end
 
     it 'defaults to a name of testing' do
-      expect(subject.name).to eq('testing')
+      expect(resource.name).to eq('testing')
     end
   end
 
@@ -82,14 +81,14 @@ describe PuppetlabsSpec::PuppetInternals do
   describe '.function_method' do
     it 'accepts an injected scope' do
       expect(Puppet::Parser::Functions).to receive(:function).with('my_func').and_return(true)
-      scope = double(described_class.scope)
+      scope = instance_double(described_class.scope.to_s)
       expect(scope).to receive(:method).with(:function_my_func).and_return(:fake_method)
       expect(described_class.function_method('my_func', scope: scope)).to eq(:fake_method)
     end
 
     it "returns nil if the function doesn't exist" do
       expect(Puppet::Parser::Functions).to receive(:function).with('my_func').and_return(false)
-      scope = double(described_class.scope)
+      scope = instance_double(described_class.scope.to_s)
       expect(described_class.function_method('my_func', scope: scope)).to be_nil
     end
   end

--- a/spec/unit/puppetlabs_spec_helper/tasks/fixtures_spec.rb
+++ b/spec/unit/puppetlabs_spec_helper/tasks/fixtures_spec.rb
@@ -84,6 +84,8 @@ describe PuppetlabsSpecHelper::Tasks::FixtureHelpers do
   end
 
   describe '.fixtures' do
+    subject(:helper) { described_class }
+
     before :each do
       # Unstub the fixtures "helpers"
       PuppetlabsSpec::Fixtures.instance_methods.each do |m|
@@ -98,8 +100,8 @@ describe PuppetlabsSpecHelper::Tasks::FixtureHelpers do
 
     context 'when file is missing' do
       it 'returns basic directories per category' do
-        expect(subject.fixtures('forge_modules')).to eq({})
-        expect(subject.fixtures('repositories')).to eq({})
+        expect(helper.fixtures('forge_modules')).to eq({})
+        expect(helper.fixtures('repositories')).to eq({})
       end
     end
 
@@ -107,8 +109,8 @@ describe PuppetlabsSpecHelper::Tasks::FixtureHelpers do
       it 'returns basic directories per category' do
         allow(File).to receive(:exist?).with('.fixtures.yml').and_return true
         allow(YAML).to receive(:load_file).with('.fixtures.yml').and_return false
-        expect(subject.fixtures('forge_modules')).to eq({})
-        expect(subject.fixtures('repositories')).to eq({})
+        expect(helper.fixtures('forge_modules')).to eq({})
+        expect(helper.fixtures('repositories')).to eq({})
       end
     end
 
@@ -116,7 +118,7 @@ describe PuppetlabsSpecHelper::Tasks::FixtureHelpers do
       it 'raises an error' do
         expect(File).to receive(:exist?).with('.fixtures.yml').and_return true
         expect(YAML).to receive(:load_file).with('.fixtures.yml').and_raise(Psych::SyntaxError.new('/file', '123', '0', '0', 'spec message', 'spec context'))
-        expect { subject.fixtures('forge_modules') }.to raise_error(RuntimeError, %r{malformed YAML})
+        expect { helper.fixtures('forge_modules') }.to raise_error(RuntimeError, %r{malformed YAML})
       end
     end
 
@@ -124,7 +126,7 @@ describe PuppetlabsSpecHelper::Tasks::FixtureHelpers do
       it 'raises an error' do
         allow(File).to receive(:exist?).with('.fixtures.yml').and_return true
         allow(YAML).to receive(:load_file).with('.fixtures.yml').and_return('some' => 'key')
-        expect { subject.fixtures('forge_modules') }.to raise_error(RuntimeError, %r{No 'fixtures'})
+        expect { helper.fixtures('forge_modules') }.to raise_error(RuntimeError, %r{No 'fixtures'})
       end
     end
 
@@ -132,14 +134,16 @@ describe PuppetlabsSpecHelper::Tasks::FixtureHelpers do
       it 'returns the hash' do
         allow(File).to receive(:exist?).with('.fixtures.yml').and_return true
         allow(YAML).to receive(:load_file).with('.fixtures.yml').and_return('fixtures' => { 'forge_modules' => { 'stdlib' => 'puppetlabs-stdlib' } })
-        expect(subject.fixtures('forge_modules')).to eq('puppetlabs-stdlib' => {
-                                                          'target' => 'spec/fixtures/modules/stdlib',
-                                                          'ref' => nil,
-                                                          'branch' => nil,
-                                                          'scm' => nil,
-                                                          'flags' => nil,
-                                                          'subdir' => nil,
-                                                        })
+        expect(helper.fixtures('forge_modules')).to eq(
+          'puppetlabs-stdlib' => {
+            'target' => 'spec/fixtures/modules/stdlib',
+            'ref' => nil,
+            'branch' => nil,
+            'scm' => nil,
+            'flags' => nil,
+            'subdir' => nil,
+          },
+        )
       end
     end
 
@@ -148,14 +152,16 @@ describe PuppetlabsSpecHelper::Tasks::FixtureHelpers do
         allow(File).to receive(:exist?).with('.fixtures.yml').and_return true
         allow(YAML).to receive(:load_file).with('.fixtures.yml').and_return('defaults' => { 'forge_modules' => { 'flags' => '--module_repository=https://myforge.example.com/' } },
                                                                             'fixtures' => { 'forge_modules' => { 'stdlib' => 'puppetlabs-stdlib' } })
-        expect(subject.fixtures('forge_modules')).to eq('puppetlabs-stdlib' => {
-                                                          'target' => 'spec/fixtures/modules/stdlib',
-                                                          'ref' => nil,
-                                                          'branch' => nil,
-                                                          'scm' => nil,
-                                                          'flags' => '--module_repository=https://myforge.example.com/',
-                                                          'subdir' => nil,
-                                                        })
+        expect(helper.fixtures('forge_modules')).to eq(
+          'puppetlabs-stdlib' => {
+            'target' => 'spec/fixtures/modules/stdlib',
+            'ref' => nil,
+            'branch' => nil,
+            'scm' => nil,
+            'flags' => '--module_repository=https://myforge.example.com/',
+            'subdir' => nil,
+          },
+        )
       end
     end
 
@@ -170,14 +176,16 @@ describe PuppetlabsSpecHelper::Tasks::FixtureHelpers do
       end
 
       it 'returns the hash' do
-        expect(subject.repositories).to eq('https://github.com/puppetlabs/puppetlabs-stdlib.git' => {
-                                             'target' => 'spec/fixtures/modules/stdlib',
-                                             'ref' => nil,
-                                             'branch' => nil,
-                                             'scm' => nil,
-                                             'flags' => nil,
-                                             'subdir' => nil,
-                                           })
+        expect(helper.repositories).to eq(
+          'https://github.com/puppetlabs/puppetlabs-stdlib.git' => {
+            'target' => 'spec/fixtures/modules/stdlib',
+            'ref' => nil,
+            'branch' => nil,
+            'scm' => nil,
+            'flags' => nil,
+            'subdir' => nil,
+          },
+        )
       end
     end
 
@@ -198,7 +206,7 @@ describe PuppetlabsSpecHelper::Tasks::FixtureHelpers do
       end
 
       it 'raises an ArgumentError' do
-        expect { subject.fixtures('repositories') }.to raise_error(ArgumentError)
+        expect { helper.fixtures('repositories') }.to raise_error(ArgumentError)
       end
     end
 
@@ -219,7 +227,7 @@ describe PuppetlabsSpecHelper::Tasks::FixtureHelpers do
             },
           },
         )
-        expect(subject.fixtures('forge_modules')).to include('puppetlabs-stdlib')
+        expect(helper.fixtures('forge_modules')).to include('puppetlabs-stdlib')
       end
 
       it 'excludes the fixture if the puppet version does not match', if: Gem::Version.new(Puppet::PUPPETVERSION) > Gem::Version.new('4') do
@@ -233,7 +241,7 @@ describe PuppetlabsSpecHelper::Tasks::FixtureHelpers do
             },
           },
         )
-        expect(subject.fixtures('forge_modules')).to eq({})
+        expect(helper.fixtures('forge_modules')).to eq({})
       end
 
       it 'includes the fixture on obsolete puppet versions', if: Gem::Version.new(Puppet::PUPPETVERSION) <= Gem::Version.new('4') do
@@ -247,7 +255,7 @@ describe PuppetlabsSpecHelper::Tasks::FixtureHelpers do
             },
           },
         )
-        expect(subject.fixtures('forge_modules')).to include('puppetlabs-stdlib')
+        expect(helper.fixtures('forge_modules')).to include('puppetlabs-stdlib')
       end
     end
   end

--- a/spec/watchr.rb
+++ b/spec/watchr.rb
@@ -14,7 +14,7 @@ def growl(message)
             (Regexp.last_match(1).to_i == 0) ? '~/.watchr_images/passed.png' : '~/.watchr_images/failed.png'
           else
             '~/.watchr_images/unknown.png'
-  end
+          end
   options = "-w -n Watchr --image '#{File.expand_path(image)}' -m '#{message}' '#{title}'"
   system %(#{growlnotify} #{options} &)
 end
@@ -35,7 +35,7 @@ def run_spec_test(file)
 end
 
 def filter_rspec(data)
-  data.split("\n").find_all { |l|
+  data.split("\n").select { |l|
     l =~ %r{^(\d+)\s+exampl\w+.*?(\d+).*?failur\w+.*?(\d+).*?pending}
   }.join("\n")
 end


### PR DESCRIPTION
The min ruby version and rubocop target version have been raised to 2.7.

This PR contains a number of rubocop fixes.