### PR TITLE
(maint) - add vendor directory to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/


### PR DESCRIPTION
this PR adds /vendor directory to the .gitignore file