### PR TITLE
(GH-372) Reset min Ruby requirement

### DIFF
--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -26,11 +26,11 @@ Gem::Specification.new do |spec|
   spec.executables = Dir['bin/**/*'].map { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.7')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.5')
 
   spec.add_runtime_dependency 'mocha', '~> 1.0'
-  spec.add_runtime_dependency 'pathspec', '~> 1.0'
-  spec.add_runtime_dependency 'puppet-lint', '~> 3.0'
+  spec.add_runtime_dependency 'pathspec', '~> 0.2'
+  spec.add_runtime_dependency 'puppet-lint', '~> 2.5.2'
   spec.add_runtime_dependency 'puppet-syntax', '~> 3.0'
   spec.add_runtime_dependency 'rspec-github', '~> 2.0'
   spec.add_runtime_dependency 'rspec-puppet', '~> 2.0'


### PR DESCRIPTION
Prior to this change the required Ruby version was set to greater than or equal to 2.7. This meant that the spec_helpers gem would not run on systems with Ruby 2.5.

This change updates the required Ruby version so that Rubies 2.5 and above are compatibel.

Additionally the following gems were downgraded for compatibility:

* pathspec is now ~> 0.2
* puppet-lint is now ~> 2.5.2