### PR TITLE
(CONT-517) Fix undefined method reverse

### DIFF
--- a/lib/puppetlabs_spec_helper/tasks/fixtures.rb
+++ b/lib/puppetlabs_spec_helper/tasks/fixtures.rb
@@ -317,7 +317,9 @@ module PuppetlabsSpecHelper
             end
           else
             # the last thread started should be the longest wait
-            item, item_opts = items.reverse.find { |_i, o| o.key?(:thread) }
+            # Rubocop seems to push towards using select here.. however the implementation today relies on the result being
+            # an array. Select returns a hash which makes it unsuitable so we need to use find_all.last.
+            item, item_opts = items.find_all { |_i, o| o.key?(:thread) }.last # rubocop:disable Performance/Detect, Style/CollectionMethods
             logger.debug "Waiting on #{item}"
             item_opts[:thread].join # wait for the thread to finish
             # now that we waited lets try again


### PR DESCRIPTION
Prior to this commit `items.find_all.last` had been repaced by `items.reverse.find`.

The change was introduced due to a Rubocop suggestion. However, it was incorrect due to the datatype of `items`.

This commit reverts the change.