### PR TITLE
Use rspec-puppet settings to configure Puppet

### DIFF
--- a/lib/puppetlabs_spec_helper/module_spec_helper.rb
+++ b/lib/puppetlabs_spec_helper/module_spec_helper.rb
@@ -69,14 +69,16 @@ RSpec.configure do |c|
   c.module_path = module_path
   c.manifest_dir = File.join(fixture_path, 'manifests')
 
+  # https://github.com/puppetlabs/rspec-puppet#strict_variables
+  c.strict_variables = ENV['STRICT_VARIABLES'] != 'no'
+  # https://github.com/puppetlabs/rspec-puppet#ordering
+  c.ordering = ENV['ORDERING'] if ENV['ORDERING']
+
   c.before :each do
     if c.mock_framework.framework_name == :rspec
       allow(Puppet.features).to receive(:root?).and_return(true)
     else
       Puppet.features.stubs(:root?).returns(true)
     end
-
-    Puppet.settings[:strict_variables] = true if ENV['STRICT_VARIABLES'] == 'yes' || ENV['STRICT_VARIABLES'] != 'no'
-    Puppet.settings[:ordering] = ENV['ORDERING'] if ENV['ORDERING']
   end
 end


### PR DESCRIPTION
rspec-puppet exposes config options for strict_variables and ordering (though ordering is dead since Puppet 6). Using these is better than directly configuring Puppet.

The strict_variables statement is simplified to remove redundant logic.