### PR TITLE
(CONT-807) Mapping RC dependencies

### DIFF
--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -30,10 +30,10 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'mocha', '~> 1.0'
   spec.add_runtime_dependency 'pathspec', '>= 0.2', '< 2.0.0'
-  spec.add_runtime_dependency 'puppet-lint', '>= 2.5.2', '< 4.0.0'
+  spec.add_runtime_dependency 'puppet-lint', '>= 3.0.0', '~> 4.0.0.rc'
   spec.add_runtime_dependency 'puppet-syntax', '~> 3.0'
   spec.add_runtime_dependency 'rspec-github', '~> 2.0'
-  spec.add_runtime_dependency 'rspec-puppet', '~> 2.0'
+  spec.add_runtime_dependency 'rspec-puppet', '>= 2.0', '~> 3.0.0.rc'
 
   spec.requirements << 'puppet, >= 7.0.0'
 end


### PR DESCRIPTION
This commit aims to map the dependencies of this RC of spec_helper to the RCs of other gems that are dependencies of spec_helper