### PR TITLE
(maint) Relax Ruby requirement

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
     - vendor/bundle/**/*
   NewCops: enable
   SuggestExtensions: false
-  TargetRubyVersion: '2.7'
+  TargetRubyVersion: '2.5'
 
 # Disabled
 Style/ClassAndModuleChildren:

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables = Dir['bin/**/*'].map { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.7')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.5')
 
   spec.add_runtime_dependency 'mocha', '~> 1.0'
   spec.add_runtime_dependency 'pathspec', '>= 0.2', '< 2.0.0'


### PR DESCRIPTION
Prior to this commit, pupeptlabs_spec_helper required Ruby >= 2.7 in its Gemspec.

Puppetserver 7, which is expected to be supported as part of PE 2021.7.z LTS through 2025, uses JRuby 9.3.y.z which targets compatibility with Ruby 2.6 and uses that in its RUBY_VERSION.

Also, Puppet 7 lists its required Ruby as >= 2.5 in the Gemspec.

This commit relaxes the gemspec's Ruby requirements from >= 2.7 to >= 2.5 to allow full compatibility with Puppet and Puppetserver 7.
