### PR TITLE
(CAT-1256) Roll out new puppet-lint gem

### DIFF
--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'mocha', '~> 1.0'
   spec.add_runtime_dependency 'pathspec', '>= 0.2', '< 2.0.0'
-  spec.add_runtime_dependency 'puppet-lint', '~> 4.0'
+  spec.add_runtime_dependency 'puppetlabs-puppet-lint', '~> 5.0'
   spec.add_runtime_dependency 'puppet-syntax', '~> 3.0'
   spec.add_runtime_dependency 'rspec-github', '~> 2.0'
   spec.add_runtime_dependency 'rspec-puppet', '~> 4.0'


### PR DESCRIPTION
Note: This PR is pending the creation of the new puppetlabs-puppet-lint gem

Updating the puppet-lint runtime dependency with the new puppet-lint gem in the puppetlabs namespace. Modules will consume this gem from spec_helper.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
