### PR TITLE
(bug) - remove obselete manfiest dir config setting & require rspec-puppet 4.x

### DIFF
--- a/lib/puppetlabs_spec_helper/module_spec_helper.rb
+++ b/lib/puppetlabs_spec_helper/module_spec_helper.rb
@@ -67,7 +67,6 @@ RSpec.configure do |c|
 
   c.environmentpath = spec_path
   c.module_path = module_path
-  c.manifest_dir = File.join(fixture_path, 'manifests')
 
   # https://github.com/puppetlabs/rspec-puppet#strict_variables
   c.strict_variables = ENV['STRICT_VARIABLES'] != 'no'

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'puppet-lint', '~> 4.0'
   spec.add_runtime_dependency 'puppet-syntax', '~> 3.0'
   spec.add_runtime_dependency 'rspec-github', '~> 2.0'
-  spec.add_runtime_dependency 'rspec-puppet', '>= 2.0'
+  spec.add_runtime_dependency 'rspec-puppet', '~> 4.0'
 
   spec.requirements << 'puppet, >= 7.0.0'
 end


### PR DESCRIPTION
## Summary
    This PR removes references to the obsolete manifest_dir puppet
    configuration setting which was removed in puppet 4.x and above.
    
    This caused spec_helper to throw `undefined method `manifest_dir='` as the latest release of rspec-puppet removed
    this setting.
## Additional Context
Also tightened the dependency on rspec-puppet to ensure breaking changes are not consumed by default.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
