### PR TITLE
(CAT-1222) - Require puppetlabs-rspec-puppet over rspec-puppet

### DIFF
--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -30,10 +30,10 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'mocha', '~> 1.0'
   spec.add_runtime_dependency 'pathspec', '>= 0.2', '< 2.0.0'
+  spec.add_runtime_dependency 'puppetlabs-rspec-puppet', '~> 5.0'
   spec.add_runtime_dependency 'puppet-lint', '~> 4.0'
   spec.add_runtime_dependency 'puppet-syntax', '~> 3.0'
   spec.add_runtime_dependency 'rspec-github', '~> 2.0'
-  spec.add_runtime_dependency 'rspec-puppet', '~> 4.0'
 
   spec.requirements << 'puppet, >= 7.0.0'
 end


### PR DESCRIPTION
## Summary
this PR requires the newer puppetlabs-rspec-puppet (official puppet supported) over rspec-puppet. (no longer officially supported by puppet).

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
