### PR TITLE
Skip non-existing paths in $MODULEPATH silently

### DIFF
--- a/lib/puppetlabs_spec_helper/module_spec_helper.rb
+++ b/lib/puppetlabs_spec_helper/module_spec_helper.rb
@@ -58,7 +58,7 @@ components = module_path.split(File::PATH_SEPARATOR).map do |dir|
 
   Dir.entries(dir).grep_v(/^\./).map { |f| File.join(dir, f, 'spec', 'lib') }
 end
-components.flatten.each do |d|
+components.compact.flatten.each do |d|
   $LOAD_PATH << d if FileTest.directory?(d) && !$LOAD_PATH.include?(d)
 end
 


### PR DESCRIPTION
## Summary

If one or more components in `$MODULEPATH` do not exist as directories, loading tests will fail with an exception.

## Additional Context

In `map`, a `next` will leave a `nil` value in the array.  This is a problem since `FileTest.directory? nil` raises "TypeError: no implicit conversion of nil into String"

I have not seen any difference in behaviour for `FileTest.directory?` or `next` in `.map` from Ruby 2.3 to 3.2.

## Related Issues (if any)

Bug was introduced in v4.0.1, in commit b6bfd6f6853dfbfafd2841e4580f79e312b7cc4a

For whatever reason, I have stuck to 2.15 for all this time, and that version handles missing directories without complaints. In my case I include "modules" as one of the elements in the path, but not all test environments has/need that directory.  It does not seem useful that users have to filter MODULEPATH on their own before launching rspec.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
