### PR TITLE
(CAT-1653) Fix rubocop warnings

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -176,7 +176,7 @@ puppet_lint_disable_checks = %w[
 ]
 
 puppet_lint_disable_checks.each do |check|
-  PuppetLint.configuration.send("disable_#{check}")
+  PuppetLint.configuration.send(:"disable_#{check}")
 end
 PuppetLint::RakeTask.new(:lint)
 


### PR DESCRIPTION
## Summary
Prior to this fix, [CI nightly](https://github.com/puppetlabs/puppetlabs_spec_helper/actions/runs/7255391258/job/19765911618) was failing with:

```bash
Run bundle exec rubocop --format github

Error: Performance/StringIdentifierArgument: Use `:"disable_#{check}"` instead of `"disable_#{check}"`.
Error: Process completed with exit code 1.
```

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
