### PR TITLE
(GH-422) - Add Safe Navigation Operator to hash['ref']

### DIFF
--- a/lib/puppetlabs_spec_helper/tasks/fixtures.rb
+++ b/lib/puppetlabs_spec_helper/tasks/fixtures.rb
@@ -151,7 +151,7 @@ module PuppetlabsSpecHelper
         return hash unless hash['scm'] == 'git'
 
         # Forward slashes in the ref aren't allowed. And is probably a branch name.
-        raise ArgumentError, "The ref for #{hash['target']} is invalid (Contains a forward slash). If this is a branch name, please use the 'branch' setting instead." if hash['ref'].include?('/')
+        raise ArgumentError, "The ref for #{hash['target']} is invalid (Contains a forward slash). If this is a branch name, please use the 'branch' setting instead." if hash['ref']&.include?('/')
 
         hash
       end


### PR DESCRIPTION
## Summary
See https://github.com/puppetlabs/puppetlabs_spec_helper/issues/422
Ref is optional in fixtures, thus can be nil. Adding the Safe Navigation Operator prevents an undefined method for Nil:nil class error
## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Fixes https://github.com/puppetlabs/puppetlabs_spec_helper/issues/422

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
