### PR TITLE
puppet-syntax: Validate hiera keys

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -192,6 +192,7 @@ PuppetSyntax.exclude_paths << 'pkg/**/*'
 PuppetSyntax.exclude_paths << 'vendor/**/*'
 PuppetSyntax.exclude_paths << '.vendor/**/*'
 PuppetSyntax.exclude_paths << 'plans/**/*'
+PuppetSyntax.check_hiera_keys = true
 
 desc 'Check syntax of Ruby files and call :syntax and :metadata_lint'
 task :validate do


### PR DESCRIPTION
For a long time puppet-syntax has support to validate hiera keys and eyaml. We should use this functionality.

https://github.com/voxpupuli/puppet-syntax?tab=readme-ov-file#configuration

From my local testing. The default output:

```terminal
$ bundle exec rake syntax
---> syntax:manifests
---> syntax:templates
---> syntax:hiera:yaml
```

Now that's a bug in puppet-syntax. It always prints the subtasks, even if they aren't executed.

If I break a hiera data file:

```diff
$ git diff data/common.yaml
diff --git a/data/common.yaml b/data/common.yaml
index ad8bb3d..4243024 100644
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -19,5 +19,5 @@ lookup_options:
     merge: 'unique'

 # Default is currently yum path
-yum::plugin::versionlock::path: /etc/yum/pluginconf.d/versionlock.list
+::yum::plugin::versionlock::path: /etc/yum/pluginconf.d/versionlock.list
 yum::settings::mainconf: /etc/yum.conf
 ```

 I get the following output:

 ```terminal
$ bundle exec rake syntax
---> syntax:manifests
---> syntax:templates
---> syntax:hiera:yaml
WARNING: data/common.yaml: Key ::yum::plugin::versionlock::path: Puppet automatic lookup will not use leading '::'
 ```

 by default puppet-syntax uses the following paths for hiera files:

 ```ruby
  @hieradata_paths = [
    '**/data/**/*.*{yaml,yml}',
    'hieradata/**/*.*{yaml,yml}',
    'hiera*.*{yaml,yml}',
  ]
```

https://github.com/voxpupuli/puppet-syntax/blob/master/lib/puppet-syntax.rb#L9-L13