### PR TITLE
puppet-syntax: Validate Hiera keys

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -193,6 +193,7 @@ PuppetSyntax.exclude_paths << 'vendor/**/*'
 PuppetSyntax.exclude_paths << '.vendor/**/*'
 PuppetSyntax.exclude_paths << 'plans/**/*'
 PuppetSyntax.check_hiera_keys = true
+PuppetSyntax.check_hiera_data = true
 
 desc 'Check syntax of Ruby files and call :syntax and :metadata_lint'
 task :validate do

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'mocha', '~> 1.0'
   spec.add_runtime_dependency 'pathspec', '>= 0.2', '< 2.0.0'
   spec.add_runtime_dependency 'puppet-lint', '~> 4.0'
-  spec.add_runtime_dependency 'puppet-syntax', '~> 4.0'
+  spec.add_runtime_dependency 'puppet-syntax', '~> 4.1'
   spec.add_runtime_dependency 'rspec-github', '~> 2.0'
   spec.add_runtime_dependency 'rspec-puppet', '~> 4.0'
 


### PR DESCRIPTION
This is a new option in puppet-syntax 4.1.0:
https://github.com/voxpupuli/puppet-syntax/pull/143

It will be enabled in puppet-syntax 5 be default:
https://github.com/voxpupuli/puppet-syntax/pull/167
