### PR TITLE
puppet-syntax: Ensure we are using 4.1.1 or newer

### DIFF
--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'mocha', '~> 1.0'
   spec.add_runtime_dependency 'pathspec', '>= 0.2', '< 2.0.0'
   spec.add_runtime_dependency 'puppet-lint', '~> 4.0'
-  spec.add_runtime_dependency 'puppet-syntax', '~> 4.1'
+  spec.add_runtime_dependency 'puppet-syntax', '~> 4.1', '>= 4.1.1'
   spec.add_runtime_dependency 'rspec-github', '~> 2.0'
   spec.add_runtime_dependency 'rspec-puppet', '~> 4.0'
 


### PR DESCRIPTION
4.1.0 had a bug in the Hiera syntax validation. This is fixed in 4.1.1. See https://github.com/voxpupuli/puppet-syntax/pull/171 for details.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
