### PR TITLE
parallel_spec_standalone: use --format progress

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -111,8 +111,9 @@ task :parallel_spec_standalone do |_t, args|
     warn 'No files for parallel_spec to run against'
   else
 
-    args = ['-t', 'rspec']
-    args.push('--').concat(ENV['CI_SPEC_OPTIONS'].strip.split).push('--') unless ENV['CI_SPEC_OPTIONS'].nil? || ENV['CI_SPEC_OPTIONS'].strip.empty?
+    args = ['--type', 'rspec']
+    additional_options = ['--format', 'progress'] + ENV['CI_SPEC_OPTIONS'].to_s.strip.split
+    args.push('--').concat(additional_options).push('--')
     args.concat(Rake::FileList[pattern].to_a)
 
     ParallelTests::CLI.new.run(args)


### PR DESCRIPTION
For the past decade, people used a .rspec_parallel to configure this. We can set it directly in the rake task. That enables us to remove the .rspec_parallel and ultimately reduces the number of files required for pdk update/modulesync.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
