### PR TITLE
(CAT-273) Remove plan exclusion from rake tasks

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -191,7 +191,6 @@ PuppetSyntax.exclude_paths << 'spec/fixtures/**/*'
 PuppetSyntax.exclude_paths << 'pkg/**/*'
 PuppetSyntax.exclude_paths << 'vendor/**/*'
 PuppetSyntax.exclude_paths << '.vendor/**/*'
-PuppetSyntax.exclude_paths << 'plans/**/*'
 PuppetSyntax.check_hiera_keys = true
 PuppetSyntax.check_hiera_data = true
 


### PR DESCRIPTION
The plan exclusion was originally added to the rake tasks due to Bolt not being able to handle syntax for them. This was the case 6 years ago but not anymore. Therefore, we can remove the exclusion from the rake.

Original PR: https://github.com/puppetlabs/puppetlabs_spec_helper/pull/270

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
