### PR TITLE
spec_standalone: apply default formatting

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -46,9 +46,8 @@ end
 task default: [:help]
 
 pattern = 'spec/{aliases,classes,defines,functions,hosts,integration,plans,tasks,type_aliases,types,unit}/**/*_spec.rb'
-
 RSpec::Core::RakeTask.new(:spec_standalone) do |t, args|
-  t.rspec_opts = []
+  t.rspec_opts = ['--format', 'documentation', '--color']
   t.rspec_opts << ENV['CI_SPEC_OPTIONS'] unless ENV['CI_SPEC_OPTIONS'].nil?
   if ENV['CI_NODE_TOTAL'] && ENV['CI_NODE_INDEX']
     ci_total = ENV['CI_NODE_TOTAL'].to_i


### PR DESCRIPTION
usually we've a .rspec file in every module:
https://github.com/puppetlabs/pdk-templates/blob/main/moduleroot/.rspec.erb

By moving this to the rake task we can delete the whole .rspec file. Similar to https://github.com/puppetlabs/puppetlabs_spec_helper/pull/446

