### PR TITLE
Revert "spec_standalone: apply default formatting"

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -46,8 +46,9 @@ end
 task default: [:help]
 
 pattern = 'spec/{aliases,classes,defines,functions,hosts,integration,plans,tasks,type_aliases,types,unit}/**/*_spec.rb'
+
 RSpec::Core::RakeTask.new(:spec_standalone) do |t, args|
-  t.rspec_opts = ['--format', 'documentation', '--color']
+  t.rspec_opts = []
   t.rspec_opts << ENV['CI_SPEC_OPTIONS'] unless ENV['CI_SPEC_OPTIONS'].nil?
   if ENV['CI_NODE_TOTAL'] && ENV['CI_NODE_INDEX']
     ci_total = ENV['CI_NODE_TOTAL'].to_i


### PR DESCRIPTION
Reverts puppetlabs/puppetlabs_spec_helper#452

Reverting this change as it is causing knock on failures within the PDK:
https://github.com/puppetlabs/pdk/actions/runs/9376052167/job/25816947136#step:6:1558