### PR TITLE
(CAT-1984) - Add forge auth to fixtures module install

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,17 @@ When specifying the repo source of the fixture you have a few options as to whic
    puppet_version: '>= 6.0.0'
    ```
 
+Using Forge Authorization
+==============
+
+In order to perform forge operations which required authorization, such as installing premium modules, you can export your forge api key as an environment variable in your terminal.
+
+```bash
+FORGE_API_KEY='your_api_key'
+```
+
+puppetlabs_spec_helper will then automatically append this key to all `puppet module install` requests when running `rake spec_prep`.
+
  **Notes:**
 
  * `ref` and `branch` can be used together to get a specific revision on a specific branch

--- a/lib/puppetlabs_spec_helper/tasks/fixtures.rb
+++ b/lib/puppetlabs_spec_helper/tasks/fixtures.rb
@@ -379,6 +379,9 @@ module PuppetlabsSpecHelper
           flags = " #{opts['flags']}" if opts['flags']
         end
 
+        forge_token = ENV.fetch('FORGE_API_KEY', nil)
+        flags += " --forge_authorization \"Bearer #{forge_token}\"" if forge_token
+
         return false if File.directory?(target) && (ref.empty? || opts['ref'] == module_version(target))
 
         # The PMT cannot handle multi threaded runs due to cache directory collisons

--- a/spec/unit/puppetlabs_spec_helper/tasks/fixture_helpers_spec.rb
+++ b/spec/unit/puppetlabs_spec_helper/tasks/fixture_helpers_spec.rb
@@ -165,6 +165,29 @@ describe PuppetlabsSpecHelper::Tasks::FixtureHelpers do
       end
     end
 
+    context 'when forge_api_key env variable is set' do
+      before do
+        # required to prevent unwanted output on stub of $CHILD_STATUS
+        RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+      end
+
+      after do
+        RSpec::Mocks.configuration.allow_message_expectations_on_nil = false
+      end
+
+      it 'correctly sets --forge_authorization' do
+        allow(ENV).to receive(:fetch).with('FORGE_API_KEY', nil).and_return('myforgeapikey')
+        # Mock the system call to prevent actual execution
+        allow_any_instance_of(Kernel).to receive(:system) do |command| # rubocop:disable RSpec/AnyInstance
+          expect(command).to include('--forge_authorization "Bearer myforgeapikey"')
+          # Simulate setting $CHILD_STATUS to a successful status
+          allow($CHILD_STATUS).to receive(:success?).and_return(true)
+          true
+        end
+        helper.download_module('puppetlabs-stdlib', 'target' => 'spec/fixtures/modules/stdlib')
+      end
+    end
+
     context 'when file specifies repository fixtures' do
       before do
         allow(File).to receive(:exist?).with('.fixtures.yml').and_return true


### PR DESCRIPTION
## Summary
Prior to this PR, users were unable to perform the install of modules which required forge authorization.

This change introduces the ability to now install modules behind authorization, by referencing an env variable set by the user, and appending this onto the `puppet module install` operation if present.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
