### PR TITLE
cleanup: remove class_parameter_defaults disable

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -170,7 +170,6 @@ puppet_lint_disable_checks = %w[
   80chars
   140chars
   class_inherits_from_params_class
-  class_parameter_defaults
   disable_autoloader_layout
   documentation
   single_quote_string_with_variables


### PR DESCRIPTION
## Summary
This check has been removed since puppet-lint 1.0.0 [1]

[1] https://github.com/puppetlabs/puppet-lint/commit/4f26f5b51dcfadc6f01cf2d1ee0c913e776a988a

## Additional Context
Copying disable config to a .puppet-lint.rc and failed to find this check. Found out that it was disabled.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified.
