### PR TITLE
(BUGFIX) Correct `disable_autoloader_layout` Lint config

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -141,7 +141,7 @@ puppet_lint_disable_checks = %w[
   80chars
   140chars
   class_inherits_from_params_class
-  disable_autoloader_layout
+  autoloader_layout
   documentation
   single_quote_string_with_variables
 ]


### PR DESCRIPTION
Noticed this as I was reviewing the lint rake task for another ticket. As it stands the configuration being sent looks to be `disable_disable_autoloader_layout`, which I doubt is correct.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
