### PR TITLE
(CAT-2281) Remove puppet 7 infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - '2.7'
           - '3.2'
           - '3.3'
     name: "spec (ruby ${{ matrix.ruby_version }})"
@@ -35,12 +34,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - '2.7'
           - '3.2'
           - '3.3'
         include:
-          - ruby_version: '2.7'
-            puppet_version: '~> 7.0'
           - ruby_version: '3.2'
             puppet_version: '~> 8.0'
           - ruby_version: '3.3'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - '2.7'
           - '3.2'
     uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"
     secrets: "inherit"
@@ -24,11 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - '2.7'
           - '3.2'
         include:
-          - ruby_version: '2.7'
-            puppet_version: '~> 7.0'
           - ruby_version: '3.2'
             puppet_version: '~> 8.0'
     uses: "puppetlabs/cat-github-actions/.github/workflows/gem_acceptance.yml@main"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,16 @@ inherit_from: .rubocop_todo.yml
 inherit_gem:
   voxpupuli-rubocop: rubocop.yml
 
+AllCops:
+  Exclude:
+    - Gemfile
+    - Rakefile
+    - spec/fixtures/**/*
+    - vendor/bundle/**/*
+  NewCops: enable
+  SuggestExtensions: false
+  TargetRubyVersion: '3.1'
+
 # Disabled
 Style/ClassAndModuleChildren:
   Enabled: false

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables = Dir['bin/**/*'].map { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.7')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.1.0')
 
   spec.add_runtime_dependency 'mocha', '>= 1.0', '< 3'
   spec.add_runtime_dependency 'pathspec', '>= 0.2', '< 3'
@@ -37,5 +37,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'voxpupuli-rubocop', '~> 2.8.0'
 
-  spec.requirements << 'puppet, >= 7.0.0'
+  spec.requirements << 'puppet, >= 8.0.0'
 end

--- a/spec/unit/puppetlabs_spec_helper/puppetlabs_spec/puppet_internals_spec.rb
+++ b/spec/unit/puppetlabs_spec_helper/puppetlabs_spec/puppet_internals_spec.rb
@@ -32,7 +32,7 @@ describe PuppetlabsSpec::PuppetInternals do
     let(:node) { described_class.node }
 
     it 'can have a defined node' do
-      expect(described_class.compiler(node: node).node).to be node
+      expect(described_class.compiler(node:).node).to be node
     end
   end
 
@@ -60,12 +60,12 @@ describe PuppetlabsSpec::PuppetInternals do
     it 'accepts an injected scope' do
       expect(Puppet::Parser::Functions).to receive(:function).with('my_func').and_return(true)
       expect(scope).to receive(:method).with(:function_my_func).and_return(:fake_method)
-      expect(described_class.function_method('my_func', scope: scope)).to eq(:fake_method)
+      expect(described_class.function_method('my_func', scope:)).to eq(:fake_method)
     end
 
     it "returns nil if the function doesn't exist" do
       expect(Puppet::Parser::Functions).to receive(:function).with('my_func').and_return(false)
-      expect(described_class.function_method('my_func', scope: scope)).to be_nil
+      expect(described_class.function_method('my_func', scope:)).to be_nil
     end
   end
 end


### PR DESCRIPTION
Puppet 7 is EOL. Therefore, we can remove the test infrastructure for it. This commit aims to clear up any testing/config infrastructure related to Puppet 7 and, by extension, Ruby 2.7.

