### PR TITLE
(MODULES-11700) Allow puppet-lint 5.x (Ruby 3.4+ compatible)

### DIFF
--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'mocha', '>= 1.0', '< 3'
   spec.add_runtime_dependency 'pathspec', '>= 0.2', '< 3'
-  spec.add_runtime_dependency 'puppet-lint', '>= 4.0', '< 6.0'
+  spec.add_runtime_dependency 'puppet-lint', '~> 5.0'
   spec.add_runtime_dependency 'puppet-syntax', '~> 4.1', '>= 4.1.1'
   spec.add_runtime_dependency 'rspec-github', '>= 2.0', '< 4'
   spec.add_runtime_dependency 'rspec-puppet', '~> 5.0'

--- a/puppetlabs_spec_helper.gemspec
+++ b/puppetlabs_spec_helper.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'mocha', '>= 1.0', '< 3'
   spec.add_runtime_dependency 'pathspec', '>= 0.2', '< 3'
-  spec.add_runtime_dependency 'puppet-lint', '~> 4.0'
+  spec.add_runtime_dependency 'puppet-lint', '>= 4.0', '< 6.0'
   spec.add_runtime_dependency 'puppet-syntax', '~> 4.1', '>= 4.1.1'
   spec.add_runtime_dependency 'rspec-github', '>= 2.0', '< 4'
   spec.add_runtime_dependency 'rspec-puppet', '~> 5.0'


### PR DESCRIPTION
## What

Pin the `puppet-lint` runtime dependency to the 5.x line so it works on Ruby 3.4+ / Puppet 9:

```diff
-  spec.add_runtime_dependency 'puppet-lint', '~> 4.0'
+  spec.add_runtime_dependency 'puppet-lint', '~> 5.0'
```

## Why

puppet-lint 4.x crashes on Ruby 3.4+; 5.x is the Ruby 3.4+ / Puppet 9 compatible line and is also compatible with the Puppet 8 pipelines. Per review, puppet-lint 4 and 5 differ internally (different lint results), so this requires one line rather than allowing both.

## Context

Unblocks the Puppet 9 support work in `puppetlabs-apache` (MODULES-11700), whose Gemfile currently pins this branch on the Puppet 9 lint lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
